### PR TITLE
bundle: exclude react from build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,11 @@ const config = {
         },
     },
 
+    externals: [
+        'react',
+        'react-dom',
+    ],
+
     module: {
         rules: [
             {


### PR DESCRIPTION
Webpack is including `React` when bundling the code, this library should be provided by the application using this library (Superdesk fails to run if using a component with hooks as multiple bundles of React are included, one from `client-core` and the other from the `ui-framework`)