### PR TITLE
Revert "bundle: exclude react from build"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,11 +27,6 @@ const config = {
         },
     },
 
-    externals: [
-        'react',
-        'react-dom',
-    ],
-
     module: {
         rules: [
             {


### PR DESCRIPTION
It breaks UI on ui-framework.superdesk.org

I will include it in next release

Reverts superdesk/superdesk-ui-framework#497