### PR TITLE
2.4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I've accidentally created a `2.4.8` release tag when the version was `2.4.7` in `package.json`. I now need another version to pick the changes from "real" `2.4.8`.