### PR TITLE
Remove <div> from Menu component

### DIFF
--- a/app-typescript/components/Menu.tsx
+++ b/app-typescript/components/Menu.tsx
@@ -131,7 +131,7 @@ export class Menu extends React.Component<IProps, {}> {
 
     render() {
         return (
-            <div>
+            <React.Fragment>
                 {
                     this.props.children(this.toggle)
                 }
@@ -167,7 +167,7 @@ export class Menu extends React.Component<IProps, {}> {
                         baseZIndex={this.props.zIndex ?? superdeskTopBarZIndex}
                     />
                 </div>
-            </div>
+            </React.Fragment>
         );
     }
 }


### PR DESCRIPTION
Extra `div` prevents some styling options, e.g. stretching an item to take full vertical space