### PR TITLE
Close after clear

### DIFF
--- a/app-typescript/components/DatePicker.tsx
+++ b/app-typescript/components/DatePicker.tsx
@@ -165,6 +165,12 @@ export class DatePicker extends React.PureComponent<IDatePicker, IState> {
                             <Button
                                 onClick={() => {
                                     this.props.onChange(null);
+                                    if (
+                                        this.instance != null
+                                        && typeof this.instance.hideOverlay === 'function'
+                                    ) {
+                                        this.instance.hideOverlay();
+                                    }
                                 }}
                                 text='Clear'
                                 data-test-id='clear-button'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
SDBELGA-819

**Description:**
The popover has to be closed once the "Clear" button has been clicked because the Calendar component from primereact has to update internally and re-render the latest value in the UI. If we don't close it, once you've set a value using the quick access buttons, you have to manually open and close the popover in order for the UI value to update.