### PR TITLE
Update _icon-font.scss

### DIFF
--- a/app/styles/_icon-font.scss
+++ b/app/styles/_icon-font.scss
@@ -303,7 +303,7 @@ $sd-icon-font: (
 );
 
 @each $name, $value in $sd-icon-font {
-    &.icon-#{$name}:before {
+    .icon-#{$name}:before {
         content: $value;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
fix sass compile error
```
SassError: Top-level selectors may not contain the parent selector "&".
    &.icon-#{$name}:before {
```