### PR TITLE
fix icon picker with updated webpack

### DIFF
--- a/app-typescript/components/IconPicker.tsx
+++ b/app-typescript/components/IconPicker.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// @ts-ignore
-import * as iconFont from '../../app/styles/_icon-font.scss';
 import { Button } from './Button';
 import { Icon } from './Icon';
 import { IItem, SelectGrid } from "./SelectGrid";
@@ -85,7 +83,7 @@ export class IconPicker extends React.PureComponent<IProps, IState> {
 }
 
 const getIcons = (translateFunction: (text: string) => string): Array<IItem> => {
-    const translatedIconNameMap: any = {
+    const translatedIconNameMap = {
         'add-gallery': 'Add Gallery',
         'add-image': 'Add Image',
         'adjust': 'Adjust',
@@ -271,11 +269,8 @@ const getIcons = (translateFunction: (text: string) => string): Array<IItem> => 
         'zoom-out': 'Zoom Out',
     };
 
-    return iconFont.icon
-        .split(', ')
-        .sort()
-        .map((icon: string) => ({
-            value: icon,
-            label: translatedIconNameMap[icon] ? translateFunction(translatedIconNameMap[icon]) : icon,
-        }));
+    return Object.keys(translatedIconNameMap).sort().map((icon) => ({
+        value: icon as keyof typeof translatedIconNameMap,
+        label: translateFunction(translatedIconNameMap[icon as keyof typeof translatedIconNameMap]),
+    }));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "4.0.21",
+  "version": "4.0.22",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",

--- a/tasks/webpack.prod.js
+++ b/tasks/webpack.prod.js
@@ -5,5 +5,6 @@ module.exports = merge(webpackConfig, {
     externals: [
         'react',
         'react-dom',
+        'angular',
     ],
 });


### PR DESCRIPTION
css-loader doesn't export the class names
to javascript if those are not css modules
but seems like there is no need for it anyhow
so I'm just dropping that import.