### PR TITLE
fix svg icon size inside avatar

### DIFF
--- a/app-typescript/components/avatar/avatar-image.tsx
+++ b/app-typescript/components/avatar/avatar-image.tsx
@@ -23,7 +23,14 @@ export class AvatarContentImage extends React.PureComponent<IPropsImageAvatar> {
                     className="sd-avatar-content sd-avatar-content--dummy-img"
                     title={tooltipText}
                 >
-                    <svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <svg
+                        width="200"
+                        height="200"
+                        viewBox="0 0 200 200"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                        style={{display: 'block', width: '100%', height: '100%'}}
+                    >
                         <circle cx="100" cy="100" r="100" fill="white" fillOpacity="0"/>
                         {/* tslint:disable-next-line:max-line-length */}
                         <path fillRule="evenodd" clipRule="evenodd" d="M40 153V145.384C40 141.557 41.16 137.981 43.16 135C49.14 126.057 66.24 119.711 77.14 118C82.74 117.115 90.16 116.538 100 116.538C109.84 116.538 117.26 117.115 122.86 118C133.76 119.711 150.86 126.057 156.84 135C158.84 137.981 160 141.557 160 145.384V153C150 165 130 180 100 180C70 180 50 165 40 153ZM100 30C122.08 30 140 47.2307 140 68.4614C140 89.6922 122.08 106.923 100 106.923C77.92 106.923 60 89.6922 60 68.4614C60 47.2307 77.92 30 100 30Z" fill="var(--sd-colour-avatar-dummy)" fillOpacity="1"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "4.0.24",
+  "version": "4.0.25",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
STT-172

![image](https://github.com/user-attachments/assets/27a8c56a-e29a-417e-881c-3ae72602e618)


Svg element size was set to 200x200. It was appearing ok visually, but computing a wrong ghost image when dragging. See [example on planning](https://github.com/user-attachments/assets/8f21122f-bf94-48cc-a22b-567c8c50f4de) (only the second list item was being dragged)
