### PR TITLE
Check if popover should close on all mouse events

### DIFF
--- a/app-typescript/components/ShowPopup.tsx
+++ b/app-typescript/components/ShowPopup.tsx
@@ -9,7 +9,7 @@ interface IPropsPopupPositioner {
     getReferenceElement(): HTMLElement;
     placement: Placement;
     onClose(): void;
-    shouldCloseOnClick?: (event: MouseEvent) => boolean;
+    shouldClose?: (event: MouseEvent | Event) => boolean;
     closeOnHoverEnd?: boolean;
     'data-test-id'?: string;
 }
@@ -36,7 +36,7 @@ export class PopupPositioner extends React.PureComponent<IPropsPopupPositioner> 
             return;
         }
 
-        if (this.props.shouldCloseOnClick != null && this.props.shouldCloseOnClick(event) === false) {
+        if (this.props.shouldClose != null && this.props.shouldClose(event) === false) {
             return;
         }
 
@@ -53,6 +53,10 @@ export class PopupPositioner extends React.PureComponent<IPropsPopupPositioner> 
             return;
         }
 
+        if (this.props.shouldClose != null && this.props.shouldClose(event) === false) {
+            return;
+        }
+
         if (this.wrapperEl.contains(event.target as Node) !== true) {
             this.props.onClose();
         }
@@ -60,6 +64,10 @@ export class PopupPositioner extends React.PureComponent<IPropsPopupPositioner> 
 
     closeOnMouseLeave(event: MouseEvent) {
         if (this.wrapperEl == null) {
+            return;
+        }
+
+        if (this.props.shouldClose != null && this.props.shouldClose(event) === false) {
             return;
         }
 
@@ -196,7 +204,7 @@ export function showPopup(
     Component: React.ComponentType<{closePopup(): void}>,
     closeOnHoverEnd?: boolean,
     onClose?: () => void,
-    shouldCloseOnClick?: (event: MouseEvent) => boolean,
+    shouldClose?: (event: MouseEvent | Event) => boolean,
 ): {close: () => void} {
     const el = document.createElement('div');
 
@@ -213,7 +221,7 @@ export function showPopup(
             getReferenceElement={() => referenceElement}
             placement={placement}
             onClose={closeFn}
-            shouldCloseOnClick={shouldCloseOnClick}
+            shouldClose={shouldClose}
             closeOnHoverEnd={closeOnHoverEnd || false}
         >
             <Component closePopup={closeFn} />

--- a/app-typescript/components/WithPopover.tsx
+++ b/app-typescript/components/WithPopover.tsx
@@ -8,7 +8,7 @@ export interface IPropsWithPopover {
     component: React.ComponentType<{closePopup(): void}>;
     closeOnHoverEnd?: boolean;
     onClose?: () => void;
-    shouldCloseOnClick?(event: MouseEvent): boolean;
+    shouldClose?(event: MouseEvent | Event): boolean;
 }
 
 /**
@@ -38,7 +38,7 @@ export class WithPopover extends React.PureComponent<IPropsWithPopover> {
                     this.closePopup = undefined;
                     this.props.onClose?.();
                 },
-                this.props.shouldCloseOnClick,
+                this.props.shouldClose,
             ).close;
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "4.0.81",
+  "version": "4.0.82",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "4.0.81",
+    "version": "4.0.82",
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
STT-1198

Solves a bug where user scrolls to see other options from a dropdown inside the popover and popover closes.