### PR TITLE
add an option to disallow clearing time input

### DIFF
--- a/app-typescript/components/TimePicker.tsx
+++ b/app-typescript/components/TimePicker.tsx
@@ -14,6 +14,7 @@ interface IProps extends IInputWrapper {
     allowSeconds?: boolean;
     headerTemplate?: React.ReactNode;
     footerTemplate?: React.ReactNode;
+    canClear?: boolean; // defaults to true
     'data-test-id'?: string;
 }
 
@@ -42,6 +43,8 @@ export class TimePicker extends React.PureComponent<IProps, IState> {
                 </div>
             );
         }
+
+        const canClear = this.props.canClear ?? true;
 
         return (
             <InputWrapper
@@ -113,7 +116,7 @@ export class TimePicker extends React.PureComponent<IProps, IState> {
                             }
                         }}
                         className={classNames('sd-input__input', {
-                            'sd-input__input--has-value': this.props.value != null,
+                            'sd-input__input--can-clear': this.props.value != null && canClear,
                         })}
                         id={this.htmlId}
                         aria-labelledby={this.htmlId + 'label'}

--- a/app/styles/_time.scss
+++ b/app/styles/_time.scss
@@ -25,7 +25,7 @@
         justify-content: center;
         z-index: 1;
         pointer-events: none;
-        
+
         .clear-time-picker {
             position: absolute;
             inset-block-start: 0;
@@ -35,7 +35,7 @@
             opacity: 0;
         }
     }
-    &:has(.sd-input__input--has-value) {
+    &:has(.sd-input__input--can-clear) {
         .icon-time {
             opacity: 1;
             transition: opacity 0.2s ease;


### PR DESCRIPTION
STT-1342

Allowing to clear is causing issues when using time picker for a list of times. Users should instead either set a desired time or remove the entire entry.

<img width="524" height="429" alt="image" src="https://github.com/user-attachments/assets/5433a64b-eb39-4f07-9380-bed01709bb2c" />
