### PR TITLE
Automate GitHub release after npm publish

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish to npm and Create Release
 
 on:
     push:
@@ -10,8 +10,12 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
             - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
             - uses: actions/setup-node@v3
               with:
                   node-version: '14'
@@ -19,5 +23,31 @@ jobs:
             - run: npm run lint
             - run: npm run build
             - uses: JS-DevTools/npm-publish@v3
+              id: publish
               with:
                   token: ${{ secrets.NPM_TOKEN }}
+
+            - name: Get package version
+              if: steps.publish.outputs.type != 'none'
+              id: package-version
+              run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+            - name: Create Git tag
+              if: steps.publish.outputs.type != 'none'
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git tag -a "v${{ steps.package-version.outputs.version }}" -m "Release v${{ steps.package-version.outputs.version }}"
+                  git push origin "v${{ steps.package-version.outputs.version }}"
+
+            - name: Create GitHub Release
+              if: steps.publish.outputs.type != 'none'
+              uses: softprops/action-gh-release@v1
+              with:
+                  tag_name: v${{ steps.package-version.outputs.version }}
+                  name: Release v${{ steps.package-version.outputs.version }}
+                  generate_release_notes: true
+                  body: |
+                      Published to npm: https://www.npmjs.com/package/superdesk-ui-framework/v/${{ steps.package-version.outputs.version }}
+                  draft: false
+                  prerelease: false


### PR DESCRIPTION
### Purpose
While I was working today in this project I've noticed that we don't really have up-to-date release notes, therefore it is a bit harder to keep track of what each version contains in it. While there are multiple releases in `npm` that haven't been documented here in Github Releases, this will help us, from now on, to automatically generate the release notes and have a documentation of the changes between releases.

### What has changed
- Enhanced the `publish-to-npm` workflow to automatically create a Git tag and GitHub Release after a successful npm publish. 