### PR TITLE
Replace `onMouseOver/onMouseOut` with `onMouseEnter/onMouseLeave` in TooltipV2

### DIFF
--- a/app-typescript/components/TooltipV2.tsx
+++ b/app-typescript/components/TooltipV2.tsx
@@ -40,10 +40,10 @@ export class TooltipV2 extends React.PureComponent<IPropsTooltipV2> {
             >
                 {(toggle) => {
                     const attributes: React.HTMLAttributes<HTMLElement> = {
-                        onMouseOver: (event) => {
+                        onMouseEnter: (event) => {
                             toggle(event.target as HTMLElement);
                         },
-                        onMouseOut: (event) => {
+                        onMouseLeave: (event) => {
                             toggle(event.target as HTMLElement);
                         },
                     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Purpose
Replace `onMouseOver`/ `onMouseOut` with `onMouseEnter` / `onMouseLeave` in TooltipV2.tsx. `mouseover/mouseout` bubble and fire for child-element transitions, causing repeated toggles and visual flicker.
`mouseenter/mouseleave` do not bubble, so the tooltip opens/closes only when entering/leaving the trigger element itself. Results in fewer handler calls, more predictable behavior with nested/interactable children, and improved UX.

[STT-1453]


[STT-1453]: https://sofab.atlassian.net/browse/STT-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ