### PR TITLE
Add `v5` and `v5.1` branches to `npm` publish workflow

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -6,6 +6,8 @@ on:
             - 'develop'
             - 'v3'
             - 'v4'
+            - 'v5.1'
+            - 'v5'
 
 jobs:
     publish:


### PR DESCRIPTION
### Purpose
Update the GitHub Actions workflow to include 'v5' and 'v5.1' branches for npm publishing. 

