### PR TITLE
[STT-1508] - Add name display to Avatar component

### DIFF
--- a/app-typescript/components/ShowPopup.tsx
+++ b/app-typescript/components/ShowPopup.tsx
@@ -186,6 +186,7 @@ export class PopupPositioner extends React.PureComponent<IPropsPopupPositioner> 
             <>
                 {ReactDOM.createPortal(
                     <div
+                        className="sd-popup-positioner"
                         ref={(el) => {
                             this.wrapperEl = el;
                         }}

--- a/app-typescript/components/avatar/avatar-group.tsx
+++ b/app-typescript/components/avatar/avatar-group.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import {Avatar, IPropsAvatar} from './avatar';
+import {Avatar, IAvatarWithTooltip, IPropsAvatar} from './avatar';
 import {AvatarContentNumber} from './avatar-number';
 import {AvatarPlaceholder, IPropsAvatarPlaceholder} from './avatar-placeholder';
 import {WithPopover} from '../WithPopover';
 
-export type IAvatarInGroup = Omit<IPropsAvatar, 'size'>;
+export type IAvatarInGroup = {nameDisplay?: IAvatarWithTooltip} & Omit<IPropsAvatar, 'size' | 'nameDisplay'>;
 export type IAvatarPlaceholderInGroup = Omit<IPropsAvatarPlaceholder, 'size'>;
 
 export type IAvatarGroupItem = IAvatarInGroup | IAvatarPlaceholderInGroup;
@@ -88,7 +88,7 @@ export class AvatarGroup extends React.PureComponent<IPropsAvatarGroup> {
                                             displayName={item.displayName}
                                             icon={item.icon}
                                             statusDot={item.statusDot}
-                                            nameDisplay="none"
+                                            nameDisplay={{kind: 'none'}}
                                         />
                                     ) : (
                                         <AvatarPlaceholder
@@ -127,9 +127,14 @@ export class AvatarGroup extends React.PureComponent<IPropsAvatarGroup> {
                     >
                         {items.slice(0, max).map((item, index) => {
                             if (isAvatar(item)) {
-                                // Override inline mode in group context - force tooltip or title mode
-                                const nameDisplay = item.nameDisplay === 'inline' ? 'tooltip' : item.nameDisplay;
-                                return <Avatar {...item} key={index} size={size} nameDisplay={nameDisplay} />;
+                                return (
+                                    <Avatar
+                                        {...item}
+                                        key={index}
+                                        size={size}
+                                        nameDisplay={item.nameDisplay ?? {kind: 'none'}}
+                                    />
+                                );
                             } else {
                                 return <AvatarPlaceholder {...item} key={index} size={this.props.size} />;
                             }
@@ -143,6 +148,7 @@ export class AvatarGroup extends React.PureComponent<IPropsAvatarGroup> {
                                     displayName=""
                                     initials={null}
                                     customContent={<AvatarContentNumber number={`${itemsOverLimit}`} />}
+                                    nameDisplay={{kind: 'none'}}
                                 />
                             </PlusButtonWrapper>
                         )}

--- a/app-typescript/components/avatar/avatar-group.tsx
+++ b/app-typescript/components/avatar/avatar-group.tsx
@@ -4,7 +4,6 @@ import {Avatar, IPropsAvatar} from './avatar';
 import {AvatarWrapper} from './avatar-wrapper';
 import {AvatarContentNumber} from './avatar-number';
 import {AvatarPlaceholder, IPropsAvatarPlaceholder} from './avatar-placeholder';
-import {Spacer} from '@sourcefabric/common';
 import {WithPopover} from '../WithPopover';
 
 export type IAvatarInGroup = Omit<IPropsAvatar, 'size'>;
@@ -81,32 +80,32 @@ export class AvatarGroup extends React.PureComponent<IPropsAvatarGroup> {
                     <div className="avatar-popup">
                         {this.props.items.map((item, index) => {
                             return someHaveDisplayName ? (
-                                <Spacer h alignItems="center" gap="16" noGrow key={index}>
-                                    {isAvatar(item) && item.displayName}
-
+                                <div className="d-flex items-center gap-1" key={index}>
                                     {isAvatar(item) ? (
                                         <Avatar
-                                            size="small"
+                                            size="medium"
                                             imageUrl={item.imageUrl}
                                             initials={item.initials}
                                             displayName={item.displayName}
                                             icon={item.icon}
                                             statusDot={item.statusDot}
+                                            nameDisplay="title"
                                         />
                                     ) : (
                                         <AvatarPlaceholder
                                             kind="plus-button"
-                                            size="small"
+                                            size="medium"
                                             icon={item.icon}
                                             onClick={item.onClick}
                                         />
                                     )}
-                                </Spacer>
+                                    {isAvatar(item) && item.displayName}
+                                </div>
                             ) : (
                                 <div>
                                     <AvatarPlaceholder
                                         kind="plus-button"
-                                        size="small"
+                                        size="medium"
                                         icon={item.icon}
                                         onClick={isAvatar(item) ? undefined : item.onClick}
                                         key={index}
@@ -129,7 +128,9 @@ export class AvatarGroup extends React.PureComponent<IPropsAvatarGroup> {
                     >
                         {items.slice(0, max).map((item, index) => {
                             if (isAvatar(item)) {
-                                return <Avatar {...item} key={index} size={size} />;
+                                // Override inline mode in group context - force tooltip or title mode
+                                const nameDisplay = item.nameDisplay === 'inline' ? 'tooltip' : item.nameDisplay;
+                                return <Avatar {...item} key={index} size={size} nameDisplay={nameDisplay} />;
                             } else {
                                 return <AvatarPlaceholder {...item} key={index} size={this.props.size} />;
                             }

--- a/app-typescript/components/avatar/avatar-group.tsx
+++ b/app-typescript/components/avatar/avatar-group.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import {Avatar, IPropsAvatar} from './avatar';
-import {AvatarWrapper} from './avatar-wrapper';
 import {AvatarContentNumber} from './avatar-number';
 import {AvatarPlaceholder, IPropsAvatarPlaceholder} from './avatar-placeholder';
 import {WithPopover} from '../WithPopover';
@@ -89,7 +88,7 @@ export class AvatarGroup extends React.PureComponent<IPropsAvatarGroup> {
                                             displayName={item.displayName}
                                             icon={item.icon}
                                             statusDot={item.statusDot}
-                                            nameDisplay="title"
+                                            nameDisplay="none"
                                         />
                                     ) : (
                                         <AvatarPlaceholder
@@ -138,9 +137,13 @@ export class AvatarGroup extends React.PureComponent<IPropsAvatarGroup> {
 
                         {itemsOverLimit > 0 && (
                             <PlusButtonWrapper onToggle={onToggle}>
-                                <AvatarWrapper size={size}>
-                                    <AvatarContentNumber number={`${itemsOverLimit}`} />
-                                </AvatarWrapper>
+                                <Avatar
+                                    size={size}
+                                    imageUrl={null}
+                                    displayName=""
+                                    initials={null}
+                                    customContent={<AvatarContentNumber number={`${itemsOverLimit}`} />}
+                                />
                             </PlusButtonWrapper>
                         )}
                     </div>

--- a/app-typescript/components/avatar/avatar-with-inline-text-wrapper.tsx
+++ b/app-typescript/components/avatar/avatar-with-inline-text-wrapper.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type {IAvatarWithInlineText, IPropsAvatar} from './avatar';
+import classNames from 'classnames';
+
+interface IProps {
+    placement: IAvatarWithInlineText['placement'];
+    displayName: IPropsAvatar['displayName'];
+    avatarElement: JSX.Element;
+}
+
+export const AvatarWithInlineTextWrapper = ({placement, avatarElement, displayName}: IProps) => {
+    return (
+        <span
+            className={classNames('sd-avatar--inline', {
+                'sd-avatar--inline--text-start': placement === 'start',
+            })}
+        >
+            {avatarElement}
+            <span className="sd-avatar--inline__text">{displayName}</span>
+        </span>
+    );
+};

--- a/app-typescript/components/avatar/avatar.tsx
+++ b/app-typescript/components/avatar/avatar.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
+import classNames from 'classnames';
 import {AvatarContentImage} from './avatar-image';
 import {AvatarWrapper} from './avatar-wrapper';
 import {AvatarContentText} from './avatar-text';
+import {Tooltip} from '../Tooltip';
 
 export interface IPropsAvatar {
     imageUrl: string | null; // nullable, but mandatory to communicate importance
@@ -35,6 +37,60 @@ export interface IPropsAvatar {
      * AvatarContentImage
      */
     customContent?: JSX.Element;
+
+    /**
+     * Controls how the name is displayed:
+     * - 'tooltip': Shows name in a tooltip (default)
+     * - 'title': Shows name in native HTML title attribute
+     * - 'inline': Shows name inline next to avatar (like Material Design Chip)
+     * Defaults to 'tooltip' if not provided
+     */
+    nameDisplay?: 'tooltip' | 'title' | 'inline';
+
+    /**
+     * Controls the position of the tooltip.
+     * Only applies when nameDisplay is 'tooltip'.
+     * Defaults to 'top' if not provided
+     */
+    tooltipFlow?: 'top' | 'left' | 'right' | 'down';
+
+    /**
+     * Controls the position of the text relative to the avatar in inline mode.
+     * Only applies when nameDisplay is 'inline'.
+     * - 'start': Text appears before the avatar
+     * - 'end': Text appears after the avatar (default)
+     * Defaults to 'end' if not provided
+     */
+    textPosition?: 'start' | 'end';
+}
+
+interface ITooltipWrapperProps {
+    tooltipText: string | null | undefined;
+    tooltipFlow?: 'top' | 'left' | 'right' | 'down';
+    children: (options: {attributes: React.HTMLAttributes<HTMLElement>}) => React.ReactNode;
+}
+
+function flowToPlacement(
+    flow: 'top' | 'left' | 'right' | 'down' | undefined,
+): 'top' | 'left' | 'right' | 'bottom' | undefined {
+    if (flow === 'down') {
+        return 'bottom';
+    }
+    return flow;
+}
+
+class TooltipWrapper extends React.PureComponent<ITooltipWrapperProps> {
+    render() {
+        const {tooltipText, tooltipFlow, children} = this.props;
+
+        return tooltipText != null && (tooltipText ?? '').length > 0 ? (
+            <Tooltip content={tooltipText} placement={flowToPlacement(tooltipFlow)}>
+                {children}
+            </Tooltip>
+        ) : (
+            <>{children({attributes: {}})}</>
+        );
+    }
 }
 
 export class Avatar extends React.PureComponent<IPropsAvatar> {
@@ -52,11 +108,28 @@ export class Avatar extends React.PureComponent<IPropsAvatar> {
             statusDot,
         } = this.props;
 
-        const tooltipCombined = [displayName, this.props.tooltip]
-            .filter((str) => (str ?? '').trim().length > 0)
-            .join('\n');
+        // Determine the name display mode (defaults to 'tooltip')
+        const nameDisplay = this.props.nameDisplay ?? 'tooltip';
 
-        return (
+        // For tooltip mode, use tooltip prop first, fallback to displayName
+        const tooltipText = this.props.tooltip ?? displayName;
+
+        // For title mode (legacy behavior), combine displayName and tooltip
+        const titleText = [displayName, this.props.tooltip].filter((str) => (str ?? '').trim().length > 0).join('\n');
+
+        const avatarContent = (() => {
+            if (customContent != null) {
+                return customContent;
+            } else if (imageUrl != null || initials == null) {
+                return (
+                    <AvatarContentImage imageUrl={imageUrl} tooltipText={nameDisplay === 'title' ? titleText : ''} />
+                );
+            } else {
+                return <AvatarContentText text={initials} tooltipText={nameDisplay === 'title' ? titleText : ''} />;
+            }
+        })();
+
+        const avatarElement = (
             <AvatarWrapper
                 size={size}
                 statusIndicator={statusIndicator ? {status: statusIndicator, tooltipText: ''} : undefined}
@@ -65,16 +138,37 @@ export class Avatar extends React.PureComponent<IPropsAvatar> {
                 statusDot={statusDot}
                 noAvatarPlaceholderColor={noAvatarPlaceholderColor}
             >
-                {(() => {
-                    if (customContent != null) {
-                        return customContent;
-                    } else if (imageUrl != null || initials == null) {
-                        return <AvatarContentImage imageUrl={imageUrl} tooltipText={tooltipCombined} />;
-                    } else {
-                        return <AvatarContentText text={initials} tooltipText={tooltipCombined} />;
-                    }
-                })()}
+                {avatarContent}
             </AvatarWrapper>
         );
+
+        // Render based on nameDisplay mode
+        if (nameDisplay === 'inline') {
+            const textPosition = this.props.textPosition ?? 'end';
+
+            return (
+                <span
+                    className={classNames('sd-avatar--inline', {
+                        'sd-avatar--inline--text-start': textPosition === 'start',
+                    })}
+                >
+                    {avatarElement}
+                    <span className="sd-avatar--inline__text">{displayName}</span>
+                </span>
+            );
+        } else if (nameDisplay === 'tooltip') {
+            return (
+                <TooltipWrapper tooltipText={tooltipText} tooltipFlow={this.props.tooltipFlow}>
+                    {({attributes}) => (
+                        <span className="d-contents" {...attributes}>
+                            {avatarElement}
+                        </span>
+                    )}
+                </TooltipWrapper>
+            );
+        } else {
+            // title mode - current behavior with title attribute
+            return avatarElement;
+        }
     }
 }

--- a/app-typescript/components/avatar/avatar.tsx
+++ b/app-typescript/components/avatar/avatar.tsx
@@ -2,18 +2,36 @@ import * as React from 'react';
 import classNames from 'classnames';
 import {AvatarContentImage} from './avatar-image';
 import {AvatarContentText} from './avatar-text';
-import {Tooltip} from '../Tooltip';
 import {Icon} from '../Icon';
+import {TooltipV2} from '../TooltipV2';
+import {AvatarWithInlineTextWrapper} from './avatar-with-inline-text-wrapper';
+import {assertNever} from '../../helpers';
+
+export type IAvatarWithTooltip = {
+    kind: 'tooltip';
+
+    /** Defaults to `top` */
+    placement?: 'top' | 'left' | 'right' | 'bottom';
+
+    /** `displayName` used if not provided */
+    content?: string;
+};
+
+export type IAvatarWithInlineText = {
+    kind: 'inline';
+
+    /** Defaults to `end` */
+    placement?: 'start' | 'end';
+};
 
 export interface IPropsAvatar {
-    imageUrl: string | null; // nullable, but mandatory to communicate importance
-    displayName: string;
+    imageUrl: string | null;
 
     /** 3 letters max */
-    initials: string | null; // nullable, but mandatory to communicate importance
+    initials: string | null;
 
+    displayName: string;
     size: 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'xx-large';
-
     statusIndicator?: 'online' | 'offline';
     administratorIndicator?: boolean;
     icon?: {
@@ -25,16 +43,10 @@ export interface IPropsAvatar {
     };
 
     /**
+     * Defaults to `strong`.
      * Color scheme for placeholder when no image is available.
-     * Defaults to 'strong'.
      */
     noAvatarPlaceholderColor?: 'subtle' | 'strong';
-
-    /**
-     * displayName is shown as tooltip by default
-     * use this if you need to add additional information (it will be added on a new line)
-     */
-    tooltip?: string;
 
     /**
      * JSX resulting from rendering of one of the following components:
@@ -44,56 +56,15 @@ export interface IPropsAvatar {
     customContent?: JSX.Element;
 
     /**
-     * Controls how the name is displayed:
-     * - 'tooltip': Shows name in a tooltip (default)
-     * - 'none': No name is displayed at all
-     * - 'inline': Shows name inline next to avatar (like Material Design Chip)
-     * Defaults to 'tooltip' if not provided
+     * Defaults to `tooltip`.
+     *
+     * Controls how `tooltip` is displayed:
+     * - `tooltip`: Shows name in a tooltip
+     * - `none`: No name is displayed at all
+     * - `inline`: Shows name inline next to avatar (like Material Design Chip)
      */
-    nameDisplay?: 'tooltip' | 'inline' | 'none';
-
-    /**
-     * Controls the position of the tooltip.
-     * Defaults to 'top' if not provided
-     */
-    tooltipFlow?: 'top' | 'left' | 'right' | 'down';
-
-    /**
-     * Controls the position of the text relative to the avatar in inline mode.
-     * Only applies when nameDisplay is 'inline'.
-     * - 'start': Text appears before the avatar
-     * - 'end': Text appears after the avatar (default)
-     * Defaults to 'end' if not provided
-     */
-    textPosition?: 'start' | 'end';
+    nameDisplay?: IAvatarWithInlineText | IAvatarWithTooltip | {kind: 'none'};
 }
-
-interface ITooltipWrapperProps {
-    tooltipText: string | null | undefined;
-    tooltipFlow?: 'top' | 'left' | 'right' | 'down';
-    children: (options: {attributes: React.HTMLAttributes<HTMLElement>}) => React.ReactNode;
-}
-
-function flowToPlacement(
-    flow: 'top' | 'left' | 'right' | 'down' | undefined,
-): 'top' | 'left' | 'right' | 'bottom' | undefined {
-    if (flow === 'down') {
-        return 'bottom';
-    }
-    return flow;
-}
-
-const TooltipWrapper = React.memo<ITooltipWrapperProps>(({tooltipText, tooltipFlow, children}) => {
-    const hasTooltip = tooltipText != null && (tooltipText ?? '').length > 0;
-
-    return hasTooltip ? (
-        <Tooltip content={tooltipText} placement={flowToPlacement(tooltipFlow)}>
-            {children}
-        </Tooltip>
-    ) : (
-        <>{children({attributes: {}})}</>
-    );
-});
 
 export const Avatar = React.memo<IPropsAvatar>((props) => {
     const {
@@ -107,14 +78,8 @@ export const Avatar = React.memo<IPropsAvatar>((props) => {
         displayName,
         customContent,
         statusDot,
-        nameDisplay = 'tooltip',
-        tooltip,
-        tooltipFlow,
-        textPosition = 'end',
+        nameDisplay = {kind: 'tooltip'},
     } = props;
-
-    // For tooltip mode, use tooltip prop first, fallback to displayName
-    const tooltipText = tooltip ?? displayName;
 
     const avatarContent = React.useMemo(() => {
         if (customContent != null) {
@@ -160,28 +125,29 @@ export const Avatar = React.memo<IPropsAvatar>((props) => {
         </span>
     );
 
-    if (nameDisplay === 'inline') {
+    const kind = nameDisplay.kind;
+
+    if (kind === 'inline') {
         return (
-            <span
-                className={classNames('sd-avatar--inline', {
-                    'sd-avatar--inline--text-start': textPosition === 'start',
-                })}
-            >
-                {avatarElement}
-                <span className="sd-avatar--inline__text">{displayName}</span>
-            </span>
+            <AvatarWithInlineTextWrapper
+                avatarElement={avatarElement}
+                displayName={displayName}
+                placement={nameDisplay.placement}
+            />
         );
-    } else if (nameDisplay === 'tooltip') {
+    } else if (kind === 'tooltip') {
         return (
-            <TooltipWrapper tooltipText={tooltipText} tooltipFlow={tooltipFlow}>
+            <TooltipV2 content={nameDisplay.content ?? displayName} placement={nameDisplay.placement}>
                 {({attributes}) => (
                     <span className="d-contents" {...attributes}>
                         {avatarElement}
                     </span>
                 )}
-            </TooltipWrapper>
+            </TooltipV2>
         );
-    } else {
+    } else if (kind === 'none') {
         return avatarElement;
+    } else {
+        assertNever(kind);
     }
 });

--- a/app-typescript/components/avatar/avatar.tsx
+++ b/app-typescript/components/avatar/avatar.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import {AvatarContentImage} from './avatar-image';
-import {AvatarWrapper} from './avatar-wrapper';
 import {AvatarContentText} from './avatar-text';
 import {Tooltip} from '../Tooltip';
+import {Icon} from '../Icon';
 
 export interface IPropsAvatar {
     imageUrl: string | null; // nullable, but mandatory to communicate importance
@@ -23,7 +23,12 @@ export interface IPropsAvatar {
     statusDot?: {
         color?: string;
     };
-    noAvatarPlaceholderColor?: 'subtle' | 'strong'; // defaults to strong; only applies to placeholder image
+
+    /**
+     * Color scheme for placeholder when no image is available.
+     * Defaults to 'strong'.
+     */
+    noAvatarPlaceholderColor?: 'subtle' | 'strong';
 
     /**
      * displayName is shown as tooltip by default
@@ -41,15 +46,14 @@ export interface IPropsAvatar {
     /**
      * Controls how the name is displayed:
      * - 'tooltip': Shows name in a tooltip (default)
-     * - 'title': Shows name in native HTML title attribute
+     * - 'none': No name is displayed at all
      * - 'inline': Shows name inline next to avatar (like Material Design Chip)
      * Defaults to 'tooltip' if not provided
      */
-    nameDisplay?: 'tooltip' | 'title' | 'inline';
+    nameDisplay?: 'tooltip' | 'inline' | 'none';
 
     /**
      * Controls the position of the tooltip.
-     * Only applies when nameDisplay is 'tooltip'.
      * Defaults to 'top' if not provided
      */
     tooltipFlow?: 'top' | 'left' | 'right' | 'down';
@@ -79,96 +83,105 @@ function flowToPlacement(
     return flow;
 }
 
-class TooltipWrapper extends React.PureComponent<ITooltipWrapperProps> {
-    render() {
-        const {tooltipText, tooltipFlow, children} = this.props;
+const TooltipWrapper = React.memo<ITooltipWrapperProps>(({tooltipText, tooltipFlow, children}) => {
+    const hasTooltip = tooltipText != null && (tooltipText ?? '').length > 0;
 
-        return tooltipText != null && (tooltipText ?? '').length > 0 ? (
-            <Tooltip content={tooltipText} placement={flowToPlacement(tooltipFlow)}>
-                {children}
-            </Tooltip>
-        ) : (
-            <>{children({attributes: {}})}</>
-        );
-    }
-}
+    return hasTooltip ? (
+        <Tooltip content={tooltipText} placement={flowToPlacement(tooltipFlow)}>
+            {children}
+        </Tooltip>
+    ) : (
+        <>{children({attributes: {}})}</>
+    );
+});
 
-export class Avatar extends React.PureComponent<IPropsAvatar> {
-    render() {
-        const {
-            imageUrl,
-            initials,
-            size,
-            statusIndicator,
-            administratorIndicator,
-            icon,
-            noAvatarPlaceholderColor,
-            displayName,
-            customContent,
-            statusDot,
-        } = this.props;
+export const Avatar = React.memo<IPropsAvatar>((props) => {
+    const {
+        imageUrl,
+        initials,
+        size,
+        statusIndicator,
+        administratorIndicator,
+        icon,
+        noAvatarPlaceholderColor,
+        displayName,
+        customContent,
+        statusDot,
+        nameDisplay = 'tooltip',
+        tooltip,
+        tooltipFlow,
+        textPosition = 'end',
+    } = props;
 
-        // Determine the name display mode (defaults to 'tooltip')
-        const nameDisplay = this.props.nameDisplay ?? 'tooltip';
+    // For tooltip mode, use tooltip prop first, fallback to displayName
+    const tooltipText = tooltip ?? displayName;
 
-        // For tooltip mode, use tooltip prop first, fallback to displayName
-        const tooltipText = this.props.tooltip ?? displayName;
-
-        // For title mode (legacy behavior), combine displayName and tooltip
-        const titleText = [displayName, this.props.tooltip].filter((str) => (str ?? '').trim().length > 0).join('\n');
-
-        const avatarContent = (() => {
-            if (customContent != null) {
-                return customContent;
-            } else if (imageUrl != null || initials == null) {
-                return (
-                    <AvatarContentImage imageUrl={imageUrl} tooltipText={nameDisplay === 'title' ? titleText : ''} />
-                );
-            } else {
-                return <AvatarContentText text={initials} tooltipText={nameDisplay === 'title' ? titleText : ''} />;
-            }
-        })();
-
-        const avatarElement = (
-            <AvatarWrapper
-                size={size}
-                statusIndicator={statusIndicator ? {status: statusIndicator, tooltipText: ''} : undefined}
-                administratorIndicator={administratorIndicator ? {enabled: true, tooltipText: ''} : undefined}
-                icon={icon}
-                statusDot={statusDot}
-                noAvatarPlaceholderColor={noAvatarPlaceholderColor}
-            >
-                {avatarContent}
-            </AvatarWrapper>
-        );
-
-        // Render based on nameDisplay mode
-        if (nameDisplay === 'inline') {
-            const textPosition = this.props.textPosition ?? 'end';
-
-            return (
-                <span
-                    className={classNames('sd-avatar--inline', {
-                        'sd-avatar--inline--text-start': textPosition === 'start',
-                    })}
-                >
-                    {avatarElement}
-                    <span className="sd-avatar--inline__text">{displayName}</span>
-                </span>
-            );
-        } else if (nameDisplay === 'tooltip') {
-            return (
-                <TooltipWrapper tooltipText={tooltipText} tooltipFlow={this.props.tooltipFlow}>
-                    {({attributes}) => (
-                        <span className="d-contents" {...attributes}>
-                            {avatarElement}
-                        </span>
-                    )}
-                </TooltipWrapper>
-            );
+    const avatarContent = React.useMemo(() => {
+        if (customContent != null) {
+            return customContent;
+        } else if (imageUrl != null || initials == null) {
+            return <AvatarContentImage imageUrl={imageUrl} tooltipText={''} />;
         } else {
-            // title mode - current behavior with title attribute
-            return avatarElement;
+            return <AvatarContentText text={initials} tooltipText={''} />;
         }
+    }, [customContent, imageUrl, initials]);
+
+    const avatarClassName = React.useMemo(
+        () =>
+            classNames('sd-avatar', {
+                'sd-avatar--x-small': size === 'x-small',
+                'sd-avatar--small': size === 'small',
+                'sd-avatar--medium': size === 'medium',
+                'sd-avatar--large': size === 'large',
+                'sd-avatar--x-large': size === 'x-large',
+                'sd-avatar--xx-large': size === 'xx-large',
+                'sd-avatar--indicator-status--online': statusIndicator === 'online',
+                'sd-avatar--indicator-status--offline': statusIndicator === 'offline',
+                'sd-avatar--empty-light': noAvatarPlaceholderColor === 'subtle',
+            }),
+        [size, statusIndicator, noAvatarPlaceholderColor],
+    );
+
+    const avatarElement = (
+        <span className={avatarClassName}>
+            {avatarContent}
+
+            {administratorIndicator === true && <i className="icon-settings sd-avatar--indicator-admin" />}
+
+            {icon != null && (
+                <span className="sd-avatar__icon">
+                    <Icon name={icon.name} color={icon.color} />
+                </span>
+            )}
+
+            {statusDot != null && (
+                <span style={{backgroundColor: statusDot.color}} className="sd-avatar__coverage-state" />
+            )}
+        </span>
+    );
+
+    if (nameDisplay === 'inline') {
+        return (
+            <span
+                className={classNames('sd-avatar--inline', {
+                    'sd-avatar--inline--text-start': textPosition === 'start',
+                })}
+            >
+                {avatarElement}
+                <span className="sd-avatar--inline__text">{displayName}</span>
+            </span>
+        );
+    } else if (nameDisplay === 'tooltip') {
+        return (
+            <TooltipWrapper tooltipText={tooltipText} tooltipFlow={tooltipFlow}>
+                {({attributes}) => (
+                    <span className="d-contents" {...attributes}>
+                        {avatarElement}
+                    </span>
+                )}
+            </TooltipWrapper>
+        );
+    } else {
+        return avatarElement;
     }
-}
+});

--- a/app/styles/_avatar.scss
+++ b/app/styles/_avatar.scss
@@ -103,6 +103,7 @@
         background-image: url('~../../images/avatar_dummy.svg');
         background-repeat: no-repeat;
         background-size: cover;
+        pointer-events: none;
     }
 
     &.sd-avatar--empty-light {

--- a/app/styles/_avatar.scss
+++ b/app/styles/_avatar.scss
@@ -92,6 +92,10 @@
 
     .sd-avatar-content--text {
         background-color: var(--sd-colour-avatar-bg);
+        cursor: default;
+        span {
+            pointer-events: none;
+        }
     }
 
     .sd-avatar-content--dummy-img {
@@ -121,6 +125,7 @@
         inset-inline-end: -4px;
         opacity: 1;
         color: var(--color-text-subdued);
+        pointer-events: none;
         [class^="icon-"], [class*=" icon-"] {
             color: inherit;
             text-shadow: -1px 1px 0 var(--sd-item__main-Bg), 1px 1px 0 var(--sd-item__main-Bg), 1px -1px 0 var(--sd-item__main-Bg), -1px -1px 0 var(--sd-item__main-Bg);
@@ -139,6 +144,7 @@
         inset-block-end: -3px;
         inset-inline-end: 3px;
         box-shadow: 0 0 0 1px var(--sd-item__main-Bg);
+        pointer-events: none;
     }
 
     &.sd-avatar--x-small {
@@ -329,8 +335,9 @@
         gap: 0;
         margin-inline-end: 8px;
 
-        > .sd-avatar {
-            margin: 0 -0.8rem 0 0;
+        > .sd-avatar,
+        > .d-contents .sd-avatar {
+            margin: 0 calc(-1 * var(--space--1)) 0 0;
             .sd-avatar-content {
                 --avatar-shadow: var(--sd-item__main-Bg);
                 box-shadow: 0 0 0 2px var(--avatar-shadow);
@@ -340,29 +347,33 @@
             }
         }
 
-        > .sd-avatar--large {
-            margin: 0 -1.2rem 0 0;
+        > .sd-avatar--large,
+        > .d-contents .sd-avatar--large {
+            margin: 0 calc(-1 * var(--space--1-5)) 0 0;
         }
 
         &.sd-avatar-group--stacked--gap-small {
-            gap: $sd-base-increment * 0.5;
-            > .sd-avatar {
+            gap: var(--gap-0-5);
+            > .sd-avatar,
+            > .d-contents .sd-avatar {
                 margin: 0;
             }
             margin-inline-end: 0;
         }
 
         &.sd-avatar-group--stacked--gap-medium {
-            gap: $sd-base-increment * 1;
-            > .sd-avatar {
+            gap: var(--gap-1);
+            > .sd-avatar,
+            > .d-contents .sd-avatar {
                 margin: 0;
             }
             margin-inline-end: 0;
         }
 
         &.sd-avatar-group--stacked--gap-large {
-            gap: $sd-base-increment * 1.5;
-            > .sd-avatar {
+            gap: var(--gap-1-5);
+            > .sd-avatar,
+            > .d-contents .sd-avatar {
                 margin: 0;
             }
             margin-inline-end: 0;
@@ -371,18 +382,141 @@
     &.sd-avatar-group--grid {
         flex-wrap: wrap;
         justify-content: flex-start;
-        gap: $sd-base-increment * 1.5;
+        gap: var(--gap-1-5);
     }
 }
 
 .avatar-popup {
     background-color: var(--color-dropdown-menu-Bg);
     border-radius: var(--b-radius--large);
-    padding: var(--space--2);
+    padding-block: var(--space--2);
+    padding-inline-start: var(--space--1-5);
     padding-inline-end: var(--space--3);
     box-shadow: var(--sd-shadow__dropdown);
     display: flex;
     flex-direction: column;
     gap: var(--gap-1-5);
     overflow: auto;
+}
+
+// Inline avatar display mode (like Material Design Chip)
+.sd-avatar--inline {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--gap-1);
+    vertical-align: middle;
+    background-color: var(--color-surface-faded);
+    border-radius: var(--b-radius--full);
+    
+
+    .sd-avatar--inline__text {
+        color: var(--color-text);
+        font-size: var(--name-font-size);
+        line-height: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        // max-width: 200px;
+        
+    }
+    &:has(.sd-avatar--x-small) {
+        gap: var(--gap-0-5);
+        .sd-avatar--inline__text {
+            --name-font-size: var(--text-size-xx-small);
+            padding-inline-end: 1em;
+        }
+    }
+    &:has(.sd-avatar--small) {
+        gap: var(--gap-0-5);
+        .sd-avatar--inline__text {
+            --name-font-size: var(--text-size-x-small);
+            padding-inline-end: 1em;
+            
+        }
+    }
+    &:has(.sd-avatar--medium) {
+        gap: var(--gap-1);
+        .sd-avatar--inline__text {
+            --name-font-size: var(--text-size-small);
+            padding-inline-end: 1em;
+        }
+    }
+    &:has(.sd-avatar--large) {
+        gap: var(--gap-1);
+        .sd-avatar--inline__text {
+            --name-font-size: var(--text-size-small);
+            padding-inline-end: 1.5em;
+        }
+    }
+    &:has(.sd-avatar--x-large) {
+        gap: var(--gap-2);
+        .sd-avatar--inline__text {
+            --name-font-size: var(--text-size-medium);
+            padding-inline-end: 2.25em;
+        }
+    }
+    &:has(.sd-avatar--xx-large) {
+        gap: var(--gap-3);
+        .sd-avatar--inline__text {
+            --name-font-size: var(--text-size-large);
+            padding-inline-end: 2.25em;
+        }
+    }
+
+    // Modifier for text-start positioning (text before avatar)
+    &.sd-avatar--inline--text-start {
+        flex-direction: row-reverse;
+
+        .sd-avatar--inline__text {
+            padding-inline-end: 0;
+            padding-inline-start: 1em;
+        }
+
+        &:has(.sd-avatar--x-small) {
+            .sd-avatar--inline__text {
+                padding-inline-start: 1em;
+            }
+        }
+        &:has(.sd-avatar--small) {
+            .sd-avatar--inline__text {
+                padding-inline-start: 1em;
+            }
+        }
+        &:has(.sd-avatar--medium) {
+            .sd-avatar--inline__text {
+                padding-inline-start: 1em;
+            }
+        }
+        &:has(.sd-avatar--large) {
+            .sd-avatar--inline__text {
+                padding-inline-start: 1.5em;
+            }
+        }
+        &:has(.sd-avatar--x-large) {
+            .sd-avatar--inline__text {
+                padding-inline-start: 2.25em;
+            }
+        }
+        &:has(.sd-avatar--xx-large) {
+            .sd-avatar--inline__text {
+                padding-inline-start: 2.25em;
+            }
+        }
+    }
+    &:not(.sd-avatar--inline--text-start) {
+        &:has(.sd-avatar--x-small) {
+            &:has(.sd-avatar__icon) {
+                .sd-avatar--inline__text {
+                    padding-inline-start: 0.5em;
+                }
+            }
+        }
+        &:has(.sd-avatar--small) {
+            &:has(.sd-avatar__icon) {
+                .sd-avatar--inline__text {
+                    padding-inline-start: 0.25em;
+                }
+            }
+        }
+    }
 }

--- a/app/styles/_tooltips.scss
+++ b/app/styles/_tooltips.scss
@@ -423,3 +423,9 @@
         }
     }
 }
+
+.sd-popup-positioner {
+	&:has(.tooltip) {
+		pointer-events: none;
+	}
+}

--- a/examples/css/docs-page.css
+++ b/examples/css/docs-page.css
@@ -21,6 +21,8 @@
         hsla(191, 53%, 86%, 1) 96%
     );
 
+    --docs-page-color-fg-highlight: oklch(0.64 0.07 220.04);
+
     --docs-page-border__window-bar--top: hsla(0, 0%, 100%, 0.9);
     --docs-page-border__window-bar--bottom: hsla(0, 0%, 88%, 1);
     --docs-page-border__table: hsla(0, 0%, 0%, 0.16);
@@ -198,7 +200,7 @@ hr {
     margin-top: -10px;
 }
 .docs-page__code-example p.docs-page__paragraph {
-    color: #7abcd1;
+    color: var(--docs-page-color-fg-highlight);
 }
 
 .docs-page__paragraph--topMarginL {
@@ -215,7 +217,7 @@ hr {
     font-weight: 600;
 }
 .docs-page .link {
-    color: #5eadc8;
+    color: var(--docs-page-color-fg-highlight);
     text-decoration: none;
 }
 .docs-page .link:hover {
@@ -626,7 +628,7 @@ hr {
     text-decoration: none;
 }
 .docs-page__window-bar > a.active {
-    color: #5eadc8;
+    color: var(--docs-page-color-fg-highlight);
 }
 .docs-page__code--large {
     font-size: 1.5rem;
@@ -751,7 +753,7 @@ pre.prettyprint {
     background-color: #fff;
 }
 .docs-page__code-example .grid .grid .grid__item {
-    border: 1px dotted #5eadc8;
+    border: 1px dotted var(--docs-page-color-fg-highlight);
 }
 .docs-page__code-example .flex-grid .flex-grid__item {
     padding: 20px;

--- a/examples/pages/components/Avatar.tsx
+++ b/examples/pages/components/Avatar.tsx
@@ -402,7 +402,9 @@ export default class AvatarDoc extends React.PureComponent {
                 </Markup.ReactMarkup>
 
                 <h3 className="docs-page__h3">Name Display Modes</h3>
-                <p className="docs-page__paragraph">Avatar supports three different ways to display the user's name:</p>
+                <p className="docs-page__paragraph">
+                    Avatar supports different ways to display (or hide) the user's name:
+                </p>
                 <Markup.ReactMarkup>
                     <Markup.ReactMarkupPreview>
                         <div className="docs-page__content-row">
@@ -432,21 +434,21 @@ export default class AvatarDoc extends React.PureComponent {
                                 />
                             </Container>
 
-                            <p className="docs-page__paragraph">// Title Mode (native HTML title)</p>
+                            <p className="docs-page__paragraph">// None Mode (no name displayed)</p>
                             <Container gap="medium" className="sd-margin-b--3">
                                 <Avatar
                                     size="large"
                                     imageUrl="/avatar.jpg"
                                     initials="JL"
                                     displayName="Jeffrey Lebowski"
-                                    nameDisplay="title"
+                                    nameDisplay="none"
                                 />
                                 <Avatar
                                     size="large"
                                     imageUrl={null}
                                     initials="WS"
                                     displayName="Walter Sobchak"
-                                    nameDisplay="title"
+                                    nameDisplay="none"
                                 />
                             </Container>
 
@@ -518,13 +520,13 @@ export default class AvatarDoc extends React.PureComponent {
                             tooltip="JJB - Professional Boxer"
                         />
 
-                        // Title Mode - uses native HTML title attribute
+                        // None Mode - no name is displayed at all
                         <Avatar
                             size="large"
                             imageUrl="/avatar.jpg"
                             initials="JL"
                             displayName="Jeffrey Lebowski"
-                            nameDisplay="title"
+                            nameDisplay="none"
                         />
 
                         // Inline Mode - displays name beside avatar
@@ -766,7 +768,7 @@ export default class AvatarDoc extends React.PureComponent {
                         {`
                         // Example: Reading from external config in your application
                         const appConfig = {
-                            avatarNameDisplay: 'inline' // or 'tooltip' or 'title'
+                            avatarNameDisplay: 'inline' // or 'tooltip' or 'none'
                             textPosition: 'start' // or 'end'
                         };
 
@@ -1105,9 +1107,9 @@ export default class AvatarDoc extends React.PureComponent {
                     <Prop
                         name="nameDisplay"
                         isRequired={false}
-                        type="'tooltip' | 'title' | 'inline'"
+                        type="'tooltip' | 'none' | 'inline'"
                         default="'tooltip'"
-                        description="Controls how the name is displayed: 'tooltip' (shows in tooltip component), 'title' (uses HTML title attribute), 'inline' (displays beside avatar)."
+                        description="Controls how the name is displayed: 'tooltip' (shows in tooltip component), 'none' (no name displayed at all), 'inline' (displays beside avatar)."
                     />
                     <Prop
                         name="tooltipFlow"

--- a/examples/pages/components/Avatar.tsx
+++ b/examples/pages/components/Avatar.tsx
@@ -380,7 +380,7 @@ export default class AvatarDoc extends React.PureComponent {
                         />
 
                         // With icon and Coverage status indicator
-                        <Avatar 
+                        <Avatar
                             displayName="Unassigned"
                             imageUrl={null}
                             initials={null}
@@ -388,7 +388,7 @@ export default class AvatarDoc extends React.PureComponent {
                             icon={{name: 'text', color: 'var(--sd-colour-state--assigned)'}}
                             statusDot={{color: 'var(--sd-colour-coverage-state--on-merit)'}}
                         />
-                        <Avatar 
+                        <Avatar
                             displayName="Unassigned"
                             imageUrl={null}
                             initials={null}
@@ -415,22 +415,21 @@ export default class AvatarDoc extends React.PureComponent {
                                     imageUrl="/avatar.jpg"
                                     initials="JL"
                                     displayName="Jeffrey Lebowski"
-                                    nameDisplay="tooltip"
+                                    nameDisplay={{kind: 'tooltip'}}
                                 />
                                 <Avatar
                                     size="large"
                                     imageUrl={null}
                                     initials="WS"
                                     displayName="Walter Sobchak"
-                                    nameDisplay="tooltip"
+                                    nameDisplay={{kind: 'tooltip'}}
                                 />
                                 <Avatar
                                     size="large"
                                     imageUrl="/avatar-3.jpg"
                                     initials="TD"
                                     displayName="Theodore Donald Kerabatsos"
-                                    nameDisplay="tooltip"
-                                    tooltip="Donny - Professional Bowler"
+                                    nameDisplay={{kind: 'tooltip', content: 'Donny - Professional Bowler'}}
                                 />
                             </Container>
 
@@ -441,14 +440,14 @@ export default class AvatarDoc extends React.PureComponent {
                                     imageUrl="/avatar.jpg"
                                     initials="JL"
                                     displayName="Jeffrey Lebowski"
-                                    nameDisplay="none"
+                                    nameDisplay={{kind: 'none'}}
                                 />
                                 <Avatar
                                     size="large"
                                     imageUrl={null}
                                     initials="WS"
                                     displayName="Walter Sobchak"
-                                    nameDisplay="none"
+                                    nameDisplay={{kind: 'none'}}
                                 />
                             </Container>
 
@@ -459,42 +458,42 @@ export default class AvatarDoc extends React.PureComponent {
                                     imageUrl={null}
                                     initials="KL"
                                     displayName="Kurt Lebowski"
-                                    nameDisplay="inline"
+                                    nameDisplay={{kind: 'inline'}}
                                 />
                                 <Avatar
                                     size="small"
                                     imageUrl="/avatar.jpg"
                                     initials="JL"
                                     displayName="Jeffrey Lebowski"
-                                    nameDisplay="inline"
+                                    nameDisplay={{kind: 'inline'}}
                                 />
                                 <Avatar
                                     size="medium"
                                     imageUrl={null}
                                     initials="WS"
                                     displayName="Walter Sobchak"
-                                    nameDisplay="inline"
+                                    nameDisplay={{kind: 'inline'}}
                                 />
                                 <Avatar
                                     size="large"
                                     imageUrl="/avatar-3.jpg"
                                     initials="JJB"
                                     displayName="Jean-Jacques Burnel"
-                                    nameDisplay="inline"
+                                    nameDisplay={{kind: 'inline'}}
                                 />
                                 <Avatar
                                     size="x-large"
                                     imageUrl="/avatar-4.jpg"
                                     initials="DH"
                                     displayName="Deborah Ann Harry"
-                                    nameDisplay="inline"
+                                    nameDisplay={{kind: 'inline'}}
                                 />
                                 <Avatar
                                     size="xx-large"
                                     imageUrl="/avatar-5.jpg"
                                     initials="CW"
                                     displayName="Christopher George Latore Wallace"
-                                    nameDisplay="inline"
+                                    nameDisplay={{kind: 'inline'}}
                                 />
                             </Container>
                         </div>
@@ -555,76 +554,62 @@ export default class AvatarDoc extends React.PureComponent {
                                 imageUrl="/avatar.jpg"
                                 initials="JL"
                                 displayName="Jeffrey Lebowski"
-                                nameDisplay="tooltip"
-                                tooltipFlow="top"
+                                nameDisplay={{kind: 'tooltip', placement: 'top'}}
                             />
                             <Avatar
                                 size="large"
                                 imageUrl="/avatar-3.jpg"
                                 initials="JJB"
                                 displayName="Jean-Jacques Burnel"
-                                nameDisplay="tooltip"
-                                tooltipFlow="right"
+                                nameDisplay={{kind: 'tooltip', placement: 'right'}}
                             />
                             <Avatar
                                 size="large"
                                 imageUrl="/avatar-4.jpg"
                                 initials="DH"
                                 displayName="Deborah Ann Harry"
-                                nameDisplay="tooltip"
-                                tooltipFlow="down"
+                                nameDisplay={{kind: 'tooltip', placement: 'bottom'}}
                             />
                             <Avatar
                                 size="large"
                                 imageUrl="/avatar-5.jpg"
                                 initials="CW"
                                 displayName="Christopher George Latore Wallace"
-                                nameDisplay="tooltip"
-                                tooltipFlow="left"
+                                nameDisplay={{kind: 'tooltip', placement: 'left'}}
                             />
                         </Container>
                     </Markup.ReactMarkupPreview>
                     <Markup.ReactMarkupCode>
                         {`
-                        // Top position (default)
-                        <Avatar
-                            size="large"
-                            imageUrl="/avatar.jpg"
-                            initials="JL"
-                            displayName="Jeffrey Lebowski"
-                            nameDisplay="tooltip"
-                            tooltipFlow="top"
-                        />
-
-                        // Right position
-                        <Avatar
-                            size="large"
-                            imageUrl="/avatar-3.jpg"
-                            initials="JJB"
-                            displayName="Jean-Jacques Burnel"
-                            nameDisplay="tooltip"
-                            tooltipFlow="right"
-                        />
-
-                        // Down position
-                        <Avatar
-                            size="large"
-                            imageUrl="/avatar-4.jpg"
-                            initials="DH"
-                            displayName="Deborah Ann Harry"
-                            nameDisplay="tooltip"
-                            tooltipFlow="down"
-                        />
-
-                        // Left position
-                        <Avatar
-                            size="large"
-                            imageUrl="/avatar-5.jpg"
-                            initials="CW"
-                            displayName="Christopher George Latore Wallace"
-                            nameDisplay="tooltip"
-                            tooltipFlow="left"
-                        />
+                            // Top position (default)
+                            <Avatar
+                                size="large"
+                                imageUrl="/avatar.jpg"
+                                initials="JL"
+                                displayName="Jeffrey Lebowski"
+                                nameDisplay={{kind: "tooltip", placement: 'top'}}
+                            />
+                            <Avatar
+                                size="large"
+                                imageUrl="/avatar-3.jpg"
+                                initials="JJB"
+                                displayName="Jean-Jacques Burnel"
+                                nameDisplay={{kind: "tooltip", placement: 'right'}}
+                            />
+                            <Avatar
+                                size="large"
+                                imageUrl="/avatar-4.jpg"
+                                initials="DH"
+                                displayName="Deborah Ann Harry"
+                                nameDisplay={{kind: "tooltip", placement: 'bottom'}}
+                            />
+                            <Avatar
+                                size="large"
+                                imageUrl="/avatar-5.jpg"
+                                initials="CW"
+                                displayName="Christopher George Latore Wallace"
+                                nameDisplay={{kind: "tooltip", placement: 'left'}}
+                            />
                     `}
                     </Markup.ReactMarkupCode>
                 </Markup.ReactMarkup>
@@ -645,23 +630,21 @@ export default class AvatarDoc extends React.PureComponent {
                                     imageUrl="/avatar.jpg"
                                     initials="JL"
                                     displayName="Jeffrey Lebowski"
-                                    nameDisplay="inline"
-                                    textPosition="end"
+                                    nameDisplay={{kind: 'inline', placement: 'end'}}
                                 />
                                 <Avatar
                                     size="medium"
                                     imageUrl={null}
                                     initials="WS"
                                     displayName="Walter Sobchak"
-                                    nameDisplay="inline"
-                                    textPosition="end"
+                                    nameDisplay={{kind: 'inline', placement: 'end'}}
                                 />
                                 <Avatar
                                     size="large"
                                     imageUrl="/avatar-3.jpg"
                                     initials="JJB"
                                     displayName="Jean-Jacques Burnel"
-                                    nameDisplay="inline"
+                                    nameDisplay={{kind: 'inline'}}
                                 />
                             </Container>
 
@@ -672,24 +655,21 @@ export default class AvatarDoc extends React.PureComponent {
                                     imageUrl="/avatar.jpg"
                                     initials="JL"
                                     displayName="Jeffrey Lebowski"
-                                    nameDisplay="inline"
-                                    textPosition="start"
+                                    nameDisplay={{kind: 'inline', placement: 'start'}}
                                 />
                                 <Avatar
                                     size="medium"
                                     imageUrl={null}
                                     initials="WS"
                                     displayName="Walter Sobchak"
-                                    nameDisplay="inline"
-                                    textPosition="start"
+                                    nameDisplay={{kind: 'inline', placement: 'start'}}
                                 />
                                 <Avatar
                                     size="large"
                                     imageUrl="/avatar-3.jpg"
                                     initials="JJB"
                                     displayName="Jean-Jacques Burnel"
-                                    nameDisplay="inline"
-                                    textPosition="start"
+                                    nameDisplay={{kind: 'inline', placement: 'start'}}
                                 />
                             </Container>
                         </div>
@@ -702,17 +682,16 @@ export default class AvatarDoc extends React.PureComponent {
                             imageUrl="/avatar.jpg"
                             initials="JL"
                             displayName="Jeffrey Lebowski"
-                            nameDisplay="inline"
-                            textPosition="end"
+                            nameDisplay={{kind: "inline", placement: "end"}}
                         />
-                        
+
                         // Omitting textPosition defaults to "end" (text after avatar)
                         <Avatar
                             size="medium"
                             imageUrl="/avatar-3.jpg"
                             initials="JJB"
                             displayName="Jean-Jacques Burnel"
-                            nameDisplay="inline"
+                            nameDisplay={{kind: "inline"}}
                         />
 
                         // Text Position: Start (text before avatar)
@@ -721,72 +700,7 @@ export default class AvatarDoc extends React.PureComponent {
                             imageUrl={null}
                             initials="WS"
                             displayName="Walter Sobchak"
-                            nameDisplay="inline"
-                            textPosition="start"
-                        />
-                    `}
-                    </Markup.ReactMarkupCode>
-                </Markup.ReactMarkup>
-
-                <h3 className="docs-page__h3">Using with External Configuration</h3>
-                <p className="docs-page__paragraph">
-                    The <code>nameDisplay</code> and <code>textPosition</code> props can be controlled from the
-                    consuming application's external configuration. This allows different customers to have different
-                    default behaviors without modifying the framework.
-                </p>
-                <Markup.ReactMarkup>
-                    <Markup.ReactMarkupPreview>
-                        {(() => {
-                            // Simulate external config from consuming application
-                            const externalConfig = {
-                                avatarNameDisplay: 'inline' as const,
-                                textPosition: 'start' as const,
-                            };
-
-                            return (
-                                <Container gap="medium" className="sd-margin-b--3" direction="row">
-                                    <Avatar
-                                        size="medium"
-                                        imageUrl="/avatar.jpg"
-                                        initials="JL"
-                                        displayName="Jeffrey Lebowski"
-                                        nameDisplay={externalConfig.avatarNameDisplay}
-                                    />
-                                    <Avatar
-                                        size="medium"
-                                        imageUrl={null}
-                                        initials="WS"
-                                        displayName="Walter Sobchak"
-                                        textPosition={externalConfig.textPosition}
-                                        nameDisplay={externalConfig.avatarNameDisplay}
-                                    />
-                                </Container>
-                            );
-                        })()}
-                    </Markup.ReactMarkupPreview>
-                    <Markup.ReactMarkupCode>
-                        {`
-                        // Example: Reading from external config in your application
-                        const appConfig = {
-                            avatarNameDisplay: 'inline' // or 'tooltip' or 'none'
-                            textPosition: 'start' // or 'end'
-                        };
-
-                        // Pass config value to individual avatars
-                        <Avatar
-                            size="medium"
-                            imageUrl="/avatar.jpg"
-                            initials="JL"
-                            displayName="Jeffrey Lebowski"
-                            nameDisplay={appConfig.avatarNameDisplay}
-                            textPosition={appConfig.textPosition}
-                        />
-                        <Avatar
-                            size="medium"
-                            imageUrl={null}
-                            initials="WS"
-                            displayName="Walter Sobchak"
-                            nameDisplay={externalConfig.avatarNameDisplay}
+                            nameDisplay={{kind: "inline", placement: "start"}}
                         />
                     `}
                     </Markup.ReactMarkupCode>

--- a/examples/pages/components/Avatar.tsx
+++ b/examples/pages/components/Avatar.tsx
@@ -1,39 +1,41 @@
 import * as React from 'react';
 import * as Markup from '../../js/react';
 
-import {Container, Avatar, AvatarGroup, AvatarPlaceholder} from '../../../app-typescript';
-import {IAvatarInGroup, IAvatarPlaceholderInGroup} from '../../../app-typescript/components/avatar/avatar-group';
+import {Container, Avatar, AvatarGroup, AvatarPlaceholder, Prop, PropsList} from '../../../app-typescript';
+import {IAvatarInGroup} from '../../../app-typescript/components/avatar/avatar-group';
 
 const avatars: Array<IAvatarInGroup> = [
     {
         imageUrl: 'avatar.jpg',
-        initials: 'U1',
-        displayName: 'User1',
+        initials: 'JL',
+        displayName: 'Jeffrey Lebowski',
     },
     {
         imageUrl: null,
-        initials: 'U2',
-        displayName: 'User2',
+        initials: 'WS',
+        displayName: 'Walter Sobchak',
+        tooltip: 'Walter Sobchak - Professional Bowler',
     },
     {
         imageUrl: null,
-        initials: 'U3',
-        displayName: 'User3',
+        initials: 'DK',
+        displayName: 'Donny Kerabatsos',
     },
     {
         imageUrl: 'avatar-3.jpg',
-        initials: 'U4',
-        displayName: 'User4',
+        initials: 'JJB',
+        displayName: 'Jean-Jacques Burnel',
+        tooltip: 'Jean-Jacques Burnel - Professional Boxer',
     },
     {
         imageUrl: 'avatar-4.jpg',
-        initials: 'U5',
-        displayName: 'User5',
+        initials: 'DH',
+        displayName: 'Deborah Ann Harry',
     },
     {
-        imageUrl: null,
-        initials: 'A6',
-        displayName: 'User6',
+        imageUrl: 'avatar-5.jpg',
+        initials: 'CW',
+        displayName: 'Christopher George Latore Wallace',
     },
 ];
 
@@ -301,35 +303,11 @@ export default class AvatarDoc extends React.PureComponent {
 
                         // With status indicator
                         <Avatar
-                            size="x-small"
-                            imageUrl="/avatar.jpg"
-                            initials="JL"
-                            displayName="Jeffrey Lebowski"
-                            statusIndicator="online"
-                        />
-
-                        <Avatar
-                            size="x-small"
-                            imageUrl="/avatar.jpg"
-                            initials="JL"
-                            displayName="Jeffrey Lebowski"
-                            statusIndicator="offline"
-                        />
-
-                        <Avatar
                             size="large"
                             imageUrl="/avatar.jpg"
                             initials="JL"
                             displayName="Jeffrey Lebowski"
                             statusIndicator="online"
-                        />
-
-                        <Avatar
-                            size="large"
-                            imageUrl="/avatar.jpg"
-                            initials="JL"
-                            displayName="Jeffrey Lebowski"
-                            statusIndicator="offline"
                         />
 
                         // With administrator indicator
@@ -381,7 +359,7 @@ export default class AvatarDoc extends React.PureComponent {
                             imageUrl={null}
                             initials={null}
                             displayName="Unassigned"
-                            emptyLight
+                            noAvatarPlaceholderColor="subtle"
                             icon={{name: 'text', color: 'var(--sd-colour-state--canceled)'}}
                         />
 
@@ -423,11 +401,407 @@ export default class AvatarDoc extends React.PureComponent {
                     </Markup.ReactMarkupCode>
                 </Markup.ReactMarkup>
 
-                <h3 className="docs-page__h3 docs-page__h3--small-top-m">AvatarGroup</h3>
-                <p className="docs-page__paragraph"></p>
+                <h3 className="docs-page__h3">Name Display Modes</h3>
+                <p className="docs-page__paragraph">Avatar supports three different ways to display the user's name:</p>
                 <Markup.ReactMarkup>
                     <Markup.ReactMarkupPreview>
-                        <p className="docs-page__paragraph">// With action</p>
+                        <div className="docs-page__content-row">
+                            <p className="docs-page__paragraph">// Tooltip Mode (default)</p>
+                            <Container gap="medium" className="sd-margin-b--3">
+                                <Avatar
+                                    size="large"
+                                    imageUrl="/avatar.jpg"
+                                    initials="JL"
+                                    displayName="Jeffrey Lebowski"
+                                    nameDisplay="tooltip"
+                                />
+                                <Avatar
+                                    size="large"
+                                    imageUrl={null}
+                                    initials="WS"
+                                    displayName="Walter Sobchak"
+                                    nameDisplay="tooltip"
+                                />
+                                <Avatar
+                                    size="large"
+                                    imageUrl="/avatar-3.jpg"
+                                    initials="TD"
+                                    displayName="Theodore Donald Kerabatsos"
+                                    nameDisplay="tooltip"
+                                    tooltip="Donny - Professional Bowler"
+                                />
+                            </Container>
+
+                            <p className="docs-page__paragraph">// Title Mode (native HTML title)</p>
+                            <Container gap="medium" className="sd-margin-b--3">
+                                <Avatar
+                                    size="large"
+                                    imageUrl="/avatar.jpg"
+                                    initials="JL"
+                                    displayName="Jeffrey Lebowski"
+                                    nameDisplay="title"
+                                />
+                                <Avatar
+                                    size="large"
+                                    imageUrl={null}
+                                    initials="WS"
+                                    displayName="Walter Sobchak"
+                                    nameDisplay="title"
+                                />
+                            </Container>
+
+                            <p className="docs-page__paragraph">// Inline Mode</p>
+                            <Container gap="medium" className="sd-margin-b--3" direction="column">
+                                <Avatar
+                                    size="x-small"
+                                    imageUrl={null}
+                                    initials="KL"
+                                    displayName="Kurt Lebowski"
+                                    nameDisplay="inline"
+                                />
+                                <Avatar
+                                    size="small"
+                                    imageUrl="/avatar.jpg"
+                                    initials="JL"
+                                    displayName="Jeffrey Lebowski"
+                                    nameDisplay="inline"
+                                />
+                                <Avatar
+                                    size="medium"
+                                    imageUrl={null}
+                                    initials="WS"
+                                    displayName="Walter Sobchak"
+                                    nameDisplay="inline"
+                                />
+                                <Avatar
+                                    size="large"
+                                    imageUrl="/avatar-3.jpg"
+                                    initials="JJB"
+                                    displayName="Jean-Jacques Burnel"
+                                    nameDisplay="inline"
+                                />
+                                <Avatar
+                                    size="x-large"
+                                    imageUrl="/avatar-4.jpg"
+                                    initials="DH"
+                                    displayName="Deborah Ann Harry"
+                                    nameDisplay="inline"
+                                />
+                                <Avatar
+                                    size="xx-large"
+                                    imageUrl="/avatar-5.jpg"
+                                    initials="CW"
+                                    displayName="Christopher George Latore Wallace"
+                                    nameDisplay="inline"
+                                />
+                            </Container>
+                        </div>
+                    </Markup.ReactMarkupPreview>
+                    <Markup.ReactMarkupCode>
+                        {`
+                        // Tooltip Mode (default) - shows name in tooltip component
+                        <Avatar
+                            size="large"
+                            imageUrl="/avatar.jpg"
+                            initials="JL"
+                            displayName="Jeffrey Lebowski"
+                            nameDisplay="tooltip"
+                        />
+
+                        // Can add additional info via tooltip prop
+                        <Avatar
+                            size="large"
+                            imageUrl="/avatar-3.jpg"
+                            initials="JJB"
+                            displayName="Jean-Jacques Burnel"
+                            nameDisplay="tooltip"
+                            tooltip="JJB - Professional Boxer"
+                        />
+
+                        // Title Mode - uses native HTML title attribute
+                        <Avatar
+                            size="large"
+                            imageUrl="/avatar.jpg"
+                            initials="JL"
+                            displayName="Jeffrey Lebowski"
+                            nameDisplay="title"
+                        />
+
+                        // Inline Mode - displays name beside avatar
+                        <Avatar
+                            size="medium"
+                            imageUrl={null}
+                            initials="WS"
+                            displayName="Walter Sobchak"
+                            nameDisplay="inline"
+                        />
+                    `}
+                    </Markup.ReactMarkupCode>
+                </Markup.ReactMarkup>
+
+                <h3 className="docs-page__h3">Tooltip Position Control</h3>
+                <p className="docs-page__paragraph">
+                    When using tooltip mode, you can control the position of the tooltip using the{' '}
+                    <code>tooltipFlow</code> prop. Available positions are: 'top' (default), 'left', 'right', and
+                    'down'.
+                </p>
+                <Markup.ReactMarkup>
+                    <Markup.ReactMarkupPreview>
+                        <Container gap="large" className="sd-margin-b--3">
+                            <Avatar
+                                size="large"
+                                imageUrl="/avatar.jpg"
+                                initials="JL"
+                                displayName="Jeffrey Lebowski"
+                                nameDisplay="tooltip"
+                                tooltipFlow="top"
+                            />
+                            <Avatar
+                                size="large"
+                                imageUrl="/avatar-3.jpg"
+                                initials="JJB"
+                                displayName="Jean-Jacques Burnel"
+                                nameDisplay="tooltip"
+                                tooltipFlow="right"
+                            />
+                            <Avatar
+                                size="large"
+                                imageUrl="/avatar-4.jpg"
+                                initials="DH"
+                                displayName="Deborah Ann Harry"
+                                nameDisplay="tooltip"
+                                tooltipFlow="down"
+                            />
+                            <Avatar
+                                size="large"
+                                imageUrl="/avatar-5.jpg"
+                                initials="CW"
+                                displayName="Christopher George Latore Wallace"
+                                nameDisplay="tooltip"
+                                tooltipFlow="left"
+                            />
+                        </Container>
+                    </Markup.ReactMarkupPreview>
+                    <Markup.ReactMarkupCode>
+                        {`
+                        // Top position (default)
+                        <Avatar
+                            size="large"
+                            imageUrl="/avatar.jpg"
+                            initials="JL"
+                            displayName="Jeffrey Lebowski"
+                            nameDisplay="tooltip"
+                            tooltipFlow="top"
+                        />
+
+                        // Right position
+                        <Avatar
+                            size="large"
+                            imageUrl="/avatar-3.jpg"
+                            initials="JJB"
+                            displayName="Jean-Jacques Burnel"
+                            nameDisplay="tooltip"
+                            tooltipFlow="right"
+                        />
+
+                        // Down position
+                        <Avatar
+                            size="large"
+                            imageUrl="/avatar-4.jpg"
+                            initials="DH"
+                            displayName="Deborah Ann Harry"
+                            nameDisplay="tooltip"
+                            tooltipFlow="down"
+                        />
+
+                        // Left position
+                        <Avatar
+                            size="large"
+                            imageUrl="/avatar-5.jpg"
+                            initials="CW"
+                            displayName="Christopher George Latore Wallace"
+                            nameDisplay="tooltip"
+                            tooltipFlow="left"
+                        />
+                    `}
+                    </Markup.ReactMarkupCode>
+                </Markup.ReactMarkup>
+
+                <h3 className="docs-page__h3">Text Position in Inline Mode</h3>
+                <p className="docs-page__paragraph">
+                    When using inline mode, you can control whether the text appears before or after the avatar using
+                    the <code>textPosition</code> prop. Use 'start' to place text before the avatar, or 'end' (default)
+                    to place it after.
+                </p>
+                <Markup.ReactMarkup>
+                    <Markup.ReactMarkupPreview>
+                        <div className="docs-page__content-row">
+                            <p className="docs-page__paragraph">// Text Position: End (default)</p>
+                            <Container gap="medium" className="sd-margin-b--3" direction="column">
+                                <Avatar
+                                    size="small"
+                                    imageUrl="/avatar.jpg"
+                                    initials="JL"
+                                    displayName="Jeffrey Lebowski"
+                                    nameDisplay="inline"
+                                    textPosition="end"
+                                />
+                                <Avatar
+                                    size="medium"
+                                    imageUrl={null}
+                                    initials="WS"
+                                    displayName="Walter Sobchak"
+                                    nameDisplay="inline"
+                                    textPosition="end"
+                                />
+                                <Avatar
+                                    size="large"
+                                    imageUrl="/avatar-3.jpg"
+                                    initials="JJB"
+                                    displayName="Jean-Jacques Burnel"
+                                    nameDisplay="inline"
+                                />
+                            </Container>
+
+                            <p className="docs-page__paragraph">// Text Position: Start</p>
+                            <Container gap="medium" className="sd-margin-b--3" direction="column">
+                                <Avatar
+                                    size="small"
+                                    imageUrl="/avatar.jpg"
+                                    initials="JL"
+                                    displayName="Jeffrey Lebowski"
+                                    nameDisplay="inline"
+                                    textPosition="start"
+                                />
+                                <Avatar
+                                    size="medium"
+                                    imageUrl={null}
+                                    initials="WS"
+                                    displayName="Walter Sobchak"
+                                    nameDisplay="inline"
+                                    textPosition="start"
+                                />
+                                <Avatar
+                                    size="large"
+                                    imageUrl="/avatar-3.jpg"
+                                    initials="JJB"
+                                    displayName="Jean-Jacques Burnel"
+                                    nameDisplay="inline"
+                                    textPosition="start"
+                                />
+                            </Container>
+                        </div>
+                    </Markup.ReactMarkupPreview>
+                    <Markup.ReactMarkupCode>
+                        {`
+                        // Text Position: End (default behavior)
+                        <Avatar
+                            size="medium"
+                            imageUrl="/avatar.jpg"
+                            initials="JL"
+                            displayName="Jeffrey Lebowski"
+                            nameDisplay="inline"
+                            textPosition="end"
+                        />
+                        
+                        // Omitting textPosition defaults to "end" (text after avatar)
+                        <Avatar
+                            size="medium"
+                            imageUrl="/avatar-3.jpg"
+                            initials="JJB"
+                            displayName="Jean-Jacques Burnel"
+                            nameDisplay="inline"
+                        />
+
+                        // Text Position: Start (text before avatar)
+                        <Avatar
+                            size="medium"
+                            imageUrl={null}
+                            initials="WS"
+                            displayName="Walter Sobchak"
+                            nameDisplay="inline"
+                            textPosition="start"
+                        />
+                    `}
+                    </Markup.ReactMarkupCode>
+                </Markup.ReactMarkup>
+
+                <h3 className="docs-page__h3">Using with External Configuration</h3>
+                <p className="docs-page__paragraph">
+                    The <code>nameDisplay</code> and <code>textPosition</code> props can be controlled from the
+                    consuming application's external configuration. This allows different customers to have different
+                    default behaviors without modifying the framework.
+                </p>
+                <Markup.ReactMarkup>
+                    <Markup.ReactMarkupPreview>
+                        {(() => {
+                            // Simulate external config from consuming application
+                            const externalConfig = {
+                                avatarNameDisplay: 'inline' as const,
+                                textPosition: 'start' as const,
+                            };
+
+                            return (
+                                <Container gap="medium" className="sd-margin-b--3" direction="row">
+                                    <Avatar
+                                        size="medium"
+                                        imageUrl="/avatar.jpg"
+                                        initials="JL"
+                                        displayName="Jeffrey Lebowski"
+                                        nameDisplay={externalConfig.avatarNameDisplay}
+                                    />
+                                    <Avatar
+                                        size="medium"
+                                        imageUrl={null}
+                                        initials="WS"
+                                        displayName="Walter Sobchak"
+                                        textPosition={externalConfig.textPosition}
+                                        nameDisplay={externalConfig.avatarNameDisplay}
+                                    />
+                                </Container>
+                            );
+                        })()}
+                    </Markup.ReactMarkupPreview>
+                    <Markup.ReactMarkupCode>
+                        {`
+                        // Example: Reading from external config in your application
+                        const appConfig = {
+                            avatarNameDisplay: 'inline' // or 'tooltip' or 'title'
+                            textPosition: 'start' // or 'end'
+                        };
+
+                        // Pass config value to individual avatars
+                        <Avatar
+                            size="medium"
+                            imageUrl="/avatar.jpg"
+                            initials="JL"
+                            displayName="Jeffrey Lebowski"
+                            nameDisplay={appConfig.avatarNameDisplay}
+                            textPosition={appConfig.textPosition}
+                        />
+                        <Avatar
+                            size="medium"
+                            imageUrl={null}
+                            initials="WS"
+                            displayName="Walter Sobchak"
+                            nameDisplay={externalConfig.avatarNameDisplay}
+                        />
+                    `}
+                    </Markup.ReactMarkupCode>
+                </Markup.ReactMarkup>
+
+                <h3 className="docs-page__h3">AvatarGroup</h3>
+                <p className="docs-page__paragraph">
+                    The <code>AvatarGroup</code> component displays multiple avatars in a compact, stacked layout. It's
+                    commonly used to show participants, assignees, or team members in a space-efficient manner.
+                </p>
+                <p className="docs-page__paragraph">
+                    <strong>Note:</strong> In <code>AvatarGroup</code>, inline mode is automatically converted to
+                    tooltip mode to maintain compact display.
+                </p>
+                <Markup.ReactMarkup>
+                    <Markup.ReactMarkupPreview>
+                        <p className="docs-page__paragraph">// Various sizes</p>
                         <AvatarGroup size="x-small" items={avatars} />
 
                         <br />
@@ -453,38 +827,38 @@ export default class AvatarDoc extends React.PureComponent {
                             const avatars: Array<IAvatarInGroup> = [
                                 {
                                     imageUrl: 'avatar.jpg',
-                                    initials: 'U1',
-                                    displayName: 'User1',
+                                    initials: 'JL',
+                                    displayName: 'Jeffrey Lebowski',
                                     icon: {name: 'print', color: 'red'},
                                 },
                                 {
                                     imageUrl: null,
-                                    initials: 'U2',
-                                    displayName: 'User2',
+                                    initials: 'WS',
+                                    displayName: 'Walter Sobchak',
                                     icon: {name: 'print', color: 'green'},
                                 },
                                 {
                                     imageUrl: null,
-                                    initials: 'U3',
-                                    displayName: 'User3',
+                                    initials: 'DK',
+                                    displayName: 'Donny Kerabatsos',
                                     icon: {name: 'print', color: 'var(--sd-colour-state--in-workflow)'},
                                 },
                                 {
                                     imageUrl: 'avatar-3.jpg',
-                                    initials: 'U4',
-                                    displayName: 'User4',
+                                    initials: 'JJB',
+                                    displayName: 'Jean-Jacques Burnel',
                                     icon: {name: 'print', color: 'var(--sd-colour-state--in-progress)'},
                                 },
                                 {
                                     imageUrl: 'avatar-4.jpg',
-                                    initials: 'U5',
-                                    displayName: 'User5',
+                                    initials: 'DH',
+                                    displayName: 'Deborah Ann Harry',
                                     icon: {name: 'print', color: 'var(--sd-colour-highlight)'},
                                 },
                                 {
-                                    imageUrl: null,
-                                    initials: 'U6',
-                                    displayName: 'User6',
+                                    imageUrl: 'avatar-5.jpg',
+                                    initials: 'CW',
+                                    displayName: 'Christopher George Latore Wallace',
                                     icon: {name: 'print', color: 'var(--sd-colour-state--in-progress)'},
                                 },
                             ];
@@ -653,6 +1027,181 @@ export default class AvatarDoc extends React.PureComponent {
                     `}
                     </Markup.ReactMarkupCode>
                 </Markup.ReactMarkup>
+
+                <h3 className="docs-page__h3">Props</h3>
+
+                <h4 className="docs-page__h4">Avatar</h4>
+                <PropsList>
+                    <Prop
+                        name="imageUrl"
+                        isRequired={true}
+                        type="string | null"
+                        default="/"
+                        description="URL of the avatar image. Pass null if no image is available."
+                    />
+                    <Prop
+                        name="displayName"
+                        isRequired={true}
+                        type="string"
+                        default="/"
+                        description="User's display name shown in tooltip or inline mode."
+                    />
+                    <Prop
+                        name="initials"
+                        isRequired={true}
+                        type="string | null"
+                        default="/"
+                        description="User's initials (max 3 letters). Pass null if not available."
+                    />
+                    <Prop
+                        name="size"
+                        isRequired={true}
+                        type="'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'xx-large'"
+                        default="/"
+                        description="Size of the avatar."
+                    />
+                    <Prop
+                        name="statusIndicator"
+                        isRequired={false}
+                        type="'online' | 'offline'"
+                        default="/"
+                        description="Shows user's online/offline status."
+                    />
+                    <Prop
+                        name="administratorIndicator"
+                        isRequired={false}
+                        type="boolean"
+                        default="false"
+                        description="Shows administrator crown indicator."
+                    />
+                    <Prop
+                        name="icon"
+                        isRequired={false}
+                        type="{name: string; color?: string}"
+                        default="/"
+                        description="Icon to display over the avatar (e.g., content type indicator)."
+                    />
+                    <Prop
+                        name="statusDot"
+                        isRequired={false}
+                        type="{color?: string}"
+                        default="/"
+                        description="Custom colored status dot (e.g., for coverage states)."
+                    />
+                    <Prop
+                        name="noAvatarPlaceholderColor"
+                        isRequired={false}
+                        type="'subtle' | 'strong'"
+                        default="'strong'"
+                        description="Color scheme for placeholder when no image is available."
+                    />
+                    <Prop
+                        name="tooltip"
+                        isRequired={false}
+                        type="string"
+                        default="/"
+                        description="Additional information to show in tooltip (added on a new line below displayName)."
+                    />
+                    <Prop
+                        name="nameDisplay"
+                        isRequired={false}
+                        type="'tooltip' | 'title' | 'inline'"
+                        default="'tooltip'"
+                        description="Controls how the name is displayed: 'tooltip' (shows in tooltip component), 'title' (uses HTML title attribute), 'inline' (displays beside avatar)."
+                    />
+                    <Prop
+                        name="tooltipFlow"
+                        isRequired={false}
+                        type="'top' | 'left' | 'right' | 'down'"
+                        default="'top'"
+                        description="Tooltip position. Only applies when nameDisplay is 'tooltip'."
+                    />
+                    <Prop
+                        name="textPosition"
+                        isRequired={false}
+                        type="'start' | 'end'"
+                        default="'end'"
+                        description="Text position relative to avatar. Only applies when nameDisplay is 'inline'. 'start' places text before avatar, 'end' places it after."
+                    />
+                    <Prop
+                        name="customContent"
+                        isRequired={false}
+                        type="JSX.Element"
+                        default="/"
+                        description="Custom content to render inside the avatar (AvatarContentText or AvatarContentImage)."
+                    />
+                </PropsList>
+
+                <h4 className="docs-page__h4">AvatarGroup</h4>
+                <PropsList>
+                    <Prop
+                        name="items"
+                        isRequired={true}
+                        type="Array<IAvatarInGroup | IAvatarPlaceholderInGroup>"
+                        default="/"
+                        description="Array of avatar or placeholder configurations. Each item has same props as Avatar or AvatarPlaceholder (excluding size)."
+                    />
+                    <Prop
+                        name="size"
+                        isRequired={true}
+                        type="'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'xx-large'"
+                        default="/"
+                        description="Size applied to all avatars in the group."
+                    />
+                    <Prop
+                        name="max"
+                        isRequired={false}
+                        type="number | 'show-all'"
+                        default="4"
+                        description="Maximum number of avatars to show inline before showing '+N' button."
+                    />
+                    <Prop
+                        name="onClick"
+                        isRequired={false}
+                        type="() => void"
+                        default="/"
+                        description="Custom click handler. If not provided, a popover with all avatars is shown when max is exceeded."
+                    />
+                </PropsList>
+
+                <h4 className="docs-page__h4">AvatarPlaceholder</h4>
+                <PropsList>
+                    <Prop
+                        name="kind"
+                        isRequired={true}
+                        type="'plus-button' | 'user-icon'"
+                        default="/"
+                        description="Type of placeholder: 'plus-button' shows add icon, 'user-icon' shows user silhouette."
+                    />
+                    <Prop
+                        name="size"
+                        isRequired={true}
+                        type="'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'xx-large'"
+                        default="/"
+                        description="Size of the placeholder avatar."
+                    />
+                    <Prop
+                        name="tooltip"
+                        isRequired={false}
+                        type="string | null"
+                        default="/"
+                        description="Tooltip text to show on hover."
+                    />
+                    <Prop
+                        name="icon"
+                        isRequired={false}
+                        type="{name: string; color?: string}"
+                        default="/"
+                        description="Icon to display over the placeholder."
+                    />
+                    <Prop
+                        name="onClick"
+                        isRequired={false}
+                        type="() => void"
+                        default="/"
+                        description="Click handler for the placeholder."
+                    />
+                </PropsList>
             </section>
         );
     }

--- a/examples/pages/playgrounds/react-playgrounds/TestGround.tsx
+++ b/examples/pages/playgrounds/react-playgrounds/TestGround.tsx
@@ -228,8 +228,7 @@ export class TestGround extends React.Component<{}, IState> {
                                 imageUrl="/avatar.jpg"
                                 initials="JL"
                                 displayName="Jeffrey Lebowski"
-                                nameDisplay="inline"
-                                textPosition="start"
+                                nameDisplay={{kind: 'inline', placement: 'start'}}
                                 administratorIndicator={true}
                                 icon={{name: 'print', color: 'var(--sd-colour-state--done)'}}
                                 statusDot={{color: 'var(--sd-colour-coverage-state--on-merit)'}}
@@ -239,8 +238,7 @@ export class TestGround extends React.Component<{}, IState> {
                                 imageUrl="/avatar.jpg"
                                 initials="JL"
                                 displayName="Jeffrey Lebowski"
-                                nameDisplay="inline"
-                                textPosition="end"
+                                nameDisplay={{kind: 'inline', placement: 'end'}}
                                 icon={{name: 'print', color: 'var(--sd-colour-state--done)'}}
                                 statusDot={{color: 'var(--sd-colour-coverage-state--on-merit)'}}
                             />
@@ -249,8 +247,7 @@ export class TestGround extends React.Component<{}, IState> {
                                 imageUrl="/avatar.jpg"
                                 initials="JL"
                                 displayName="Jeffrey Lebowski"
-                                nameDisplay="inline"
-                                textPosition="end"
+                                nameDisplay={{kind: 'inline', placement: 'end'}}
                                 icon={{name: 'print', color: 'var(--sd-colour-state--done)'}}
                                 statusDot={{color: 'var(--sd-colour-coverage-state--on-merit)'}}
                             />
@@ -259,8 +256,7 @@ export class TestGround extends React.Component<{}, IState> {
                                 imageUrl={null}
                                 initials="PH"
                                 displayName="Peter Hook"
-                                nameDisplay="inline"
-                                textPosition="end"
+                                nameDisplay={{kind: 'inline', placement: 'end'}}
                             />
                             <Avatar size="large" imageUrl={null} initials="WS" displayName="Walter Sobchak" />
                         </Container>

--- a/examples/pages/playgrounds/react-playgrounds/TestGround.tsx
+++ b/examples/pages/playgrounds/react-playgrounds/TestGround.tsx
@@ -222,6 +222,51 @@ export class TestGround extends React.Component<{}, IState> {
 
                         <hr />
 
+                        <Container gap="large" className="sd-border--medium text-md p-2 radius-lg mb-3">
+                            <Avatar
+                                size="large"
+                                imageUrl="/avatar.jpg"
+                                initials="JL"
+                                displayName="Jeffrey Lebowski"
+                                nameDisplay="inline"
+                                textPosition="start"
+                                administratorIndicator={true}
+                                icon={{name: 'print', color: 'var(--sd-colour-state--done)'}}
+                                statusDot={{color: 'var(--sd-colour-coverage-state--on-merit)'}}
+                            />
+                            <Avatar
+                                size="x-small"
+                                imageUrl="/avatar.jpg"
+                                initials="JL"
+                                displayName="Jeffrey Lebowski"
+                                nameDisplay="inline"
+                                textPosition="end"
+                                icon={{name: 'print', color: 'var(--sd-colour-state--done)'}}
+                                statusDot={{color: 'var(--sd-colour-coverage-state--on-merit)'}}
+                            />
+                            <Avatar
+                                size="small"
+                                imageUrl="/avatar.jpg"
+                                initials="JL"
+                                displayName="Jeffrey Lebowski"
+                                nameDisplay="inline"
+                                textPosition="end"
+                                icon={{name: 'print', color: 'var(--sd-colour-state--done)'}}
+                                statusDot={{color: 'var(--sd-colour-coverage-state--on-merit)'}}
+                            />
+                            <Avatar
+                                size="small"
+                                imageUrl={null}
+                                initials="PH"
+                                displayName="Peter Hook"
+                                nameDisplay="inline"
+                                textPosition="end"
+                            />
+                            <Avatar size="large" imageUrl={null} initials="WS" displayName="Walter Sobchak" />
+                        </Container>
+
+                        <hr />
+
                         <Container gap="large" className="sd-border--medium text-md p-0 radius-lg mb-3">
                             <ResizablePanels direction="horizontal" secondarySize={{default: 20}}>
                                 <div className="left-panel p-2">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superdesk-ui-framework",
-  "version": "5.2.4",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "5.2.4",
+    "version": "6.0.0",
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "5.2.3",
+    "version": "5.2.4",
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Purpose
Enhance the Avatar component with configurable name display modes to support different customer requirements and improve UX flexibility.

### What has changed
- Added nameDisplay prop with three modes: tooltip (default), title (HTML title attribute), and inline (chip-style)
- Added tooltipFlow prop to control tooltip position ('top', 'left', 'right', 'down')
- Added textPosition prop for inline mode ('start', 'end')
- Fixed pointer-events issues on tooltips, status dots, and icons to prevent flickering
- Updated AvatarGroup to automatically convert inline mode to tooltip mode
- Added comprehensive documentation with examples and props reference
- Version bump to 5.2.4

### Steps to test
1. Navigate to Avatar component page in the examples
2. Test tooltip mode - hover to see tooltips with different positions (top, left, right, down)
3. Test inline mode - verify text appears beside avatar with proper positioning (start/end)
4. Test title mode - verify native browser tooltip appears on hover
5. Test AvatarGroup - verify groups work correctly and inline mode converts to tooltip
6. Verify no tooltip flickering when hovering over avatars with status indicators

### Screenshots
<img width="891" height="962" alt="Avatar_dsiplay_modes" src="https://github.com/user-attachments/assets/574c3a2a-12f3-4441-bfee-6952fd55a5ec" />

[STT-1508]


[STT-1508]: https://sofab.atlassian.net/browse/STT-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ