### PR TITLE
[STT-1538] - Fix crash in month navigator label rendering

### DIFF
--- a/app-typescript/components/DatePicker.tsx
+++ b/app-typescript/components/DatePicker.tsx
@@ -337,6 +337,13 @@ export class DatePickerISO extends React.PureComponent<IDatePickerISO> {
     }
 }
 
+function getOptionLabel(options: Array<{id: string; label?: string}>, id: string | null | undefined): string {
+    if (id == null) {
+        return '';
+    }
+    return options.find((option) => option.id === id)?.label ?? id;
+}
+
 const MonthNavigator = ({
     value,
     options,
@@ -346,7 +353,7 @@ const MonthNavigator = ({
         kind="synchronous"
         value={[value]}
         getOptions={() => options.map((option) => ({value: option.id}))}
-        getLabel={(option) => options[parseInt(option, 10)].label}
+        getLabel={(optionId) => getOptionLabel(options, optionId)}
         getId={(option) => option}
         onChange={(selected) => {
             onChange(selected[0]);
@@ -355,7 +362,7 @@ const MonthNavigator = ({
         labelHidden
         valueTemplate={(item) => (
             <div className="sd-datepicker__navigator-value sd-datepicker__navigator-month">
-                <div>{options[parseInt(item, 10)].label}</div>
+                <div>{getOptionLabel(options, item)}</div>
                 <Icon name="chevron-down-thin" />
             </div>
         )}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "5.1.5",
+    "version": "5.1.6",
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Purpose
Fix a crash in the date picker month navigator that caused the “Start date” / “End date” fields in the Subscriber edit form to disappear when clicked.

### What has changed
- Updated DatePicker month navigator to resolve the selected month label safely  instead of relying on positional indexing. 

### Steps to test
1. Run the project and go to Settings → Subscribers.
2. Click Edit on any subscriber or add a new subscriber
3. Click Start/End date. Calendar should open and stay visible and there should be no console errors like can't access property 

[STT-1538](https://sofab.atlassian.net/browse/STT-1538)


[STT-1538]: https://sofab.atlassian.net/browse/STT-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ