### PR TITLE
[STT-1538] - Fix crash in month navigator label rendering

### DIFF
--- a/app-typescript/components/DatePicker.tsx
+++ b/app-typescript/components/DatePicker.tsx
@@ -337,6 +337,13 @@ export class DatePickerISO extends React.PureComponent<IDatePickerISO> {
     }
 }
 
+function getOptionLabel(options: Array<{id: string; label?: string}>, id: string | null | undefined): string {
+    if (id == null) {
+        return '';
+    }
+    return options.find((option) => option.id === id)?.label ?? id;
+}
+
 const MonthNavigator = ({
     value,
     options,
@@ -346,7 +353,7 @@ const MonthNavigator = ({
         kind="synchronous"
         value={[value]}
         getOptions={() => options.map((option) => ({value: option.id}))}
-        getLabel={(option) => options[parseInt(option, 10)].label}
+        getLabel={(optionId) => getOptionLabel(options, optionId)}
         getId={(option) => option}
         onChange={(selected) => {
             onChange(selected[0]);
@@ -355,7 +362,7 @@ const MonthNavigator = ({
         labelHidden
         valueTemplate={(item) => (
             <div className="sd-datepicker__navigator-value sd-datepicker__navigator-month">
-                <div>{options[parseInt(item, 10)].label}</div>
+                <div>{getOptionLabel(options, item)}</div>
                 <Icon name="chevron-down-thin" />
             </div>
         )}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "6.0.1",
+    "version": "6.0.2",
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Purpose
This PR is a replica of this [PR](https://github.com/superdesk/superdesk-ui-framework/pull/1005) but now based off develop branch. So that the client core (release/3.2 used in STT next) can be updated to v6.0.2 of ui-framework and be tested for this fix

[STT-1538]([STT-1538] - Fix crash in month navigator label rendering)


[STT-1538]: https://sofab.atlassian.net/browse/STT-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STT-1538]: https://sofab.atlassian.net/browse/STT-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ