### PR TITLE
[STT-1509] - Added StateLabel component

### DIFF
--- a/app-typescript/components/StateLabel.tsx
+++ b/app-typescript/components/StateLabel.tsx
@@ -25,6 +25,24 @@ interface IStateColorConfig {
     style?: 'filled' | 'hollow';
 }
 
+const DEFAULT_STATE_COLOR_MAP: Record<string, IStateColorConfig> = {
+    draft: {type: 'default', style: 'hollow'},
+    ingested: {type: 'primary', style: 'hollow'},
+    routed: {type: 'primary', style: 'hollow'},
+    fetched: {type: 'primary', style: 'hollow'},
+    submitted: {type: 'warning', style: 'hollow'},
+    in_progress: {type: 'warning', style: 'hollow'},
+    published: {type: 'success', style: 'hollow'},
+    spiked: {type: 'alert', style: 'hollow'},
+    recalled: {type: 'alert', style: 'hollow'},
+    killed: {type: 'alert', style: 'hollow'},
+    scheduled: {type: 'highlight', style: 'hollow'},
+    corrected: {type: 'sd-green', style: 'hollow'},
+    correction: {color: 'pink--500', style: 'filled'},
+    being_corrected: {color: 'pink--500', style: 'hollow'},
+    unpublished: {type: 'alert', style: 'hollow'},
+};
+
 interface IProps {
     state: StateType;
     text: string;
@@ -36,28 +54,10 @@ interface IProps {
 }
 
 export class StateLabel extends React.PureComponent<IProps> {
-    private defaultStateColorMap: Record<string, IStateColorConfig> = {
-        draft: {type: 'default', style: 'hollow'},
-        ingested: {type: 'primary', style: 'hollow'},
-        routed: {type: 'primary', style: 'hollow'},
-        fetched: {type: 'primary', style: 'hollow'},
-        submitted: {type: 'warning', style: 'hollow'},
-        in_progress: {type: 'warning', style: 'hollow'},
-        published: {type: 'success', style: 'hollow'},
-        spiked: {type: 'alert', style: 'hollow'},
-        recalled: {type: 'alert', style: 'hollow'},
-        killed: {type: 'alert', style: 'hollow'},
-        scheduled: {type: 'highlight', style: 'hollow'},
-        corrected: {type: 'sd-green', style: 'hollow'},
-        correction: {color: 'pink--500', style: 'filled'},
-        being_corrected: {color: 'pink--500', style: 'hollow'},
-        unpublished: {type: 'alert', style: 'hollow'},
-    };
-
     private getColorConfig(state: StateType): IStateColorConfig {
         const {mappingOverride} = this.props;
         const override = mappingOverride?.[state];
-        const defaultConfig = this.defaultStateColorMap[state] || {type: 'default'};
+        const defaultConfig = DEFAULT_STATE_COLOR_MAP[state] || {type: 'default'};
 
         return override ? {...defaultConfig, ...override} : defaultConfig;
     }

--- a/app-typescript/components/StateLabel.tsx
+++ b/app-typescript/components/StateLabel.tsx
@@ -1,23 +1,6 @@
 import * as React from 'react';
 import {Label} from './Label';
 
-type StateType =
-    | 'draft'
-    | 'ingested'
-    | 'routed'
-    | 'fetched'
-    | 'submitted'
-    | 'in_progress'
-    | 'published'
-    | 'spiked'
-    | 'scheduled'
-    | 'corrected'
-    | 'killed'
-    | 'recalled'
-    | 'unpublished'
-    | 'correction'
-    | 'being_corrected';
-
 interface IStateColorConfig {
     type?: 'default' | 'primary' | 'success' | 'warning' | 'alert' | 'highlight' | 'sd-green';
     color?: string;
@@ -25,17 +8,17 @@ interface IStateColorConfig {
 }
 
 interface IProps {
-    state: StateType;
+    state: string;
     text: string;
     onClick?: () => void;
     color?: string;
     noTransform?: boolean;
     size?: 'small' | 'normal' | 'large';
-    mappingOverride?: Partial<Record<StateType, IStateColorConfig>>;
+    mappingOverride?: Record<string, IStateColorConfig>;
 }
 
 export class StateLabel extends React.PureComponent<IProps> {
-    private stateColorMap: Record<StateType, IStateColorConfig> = {
+    private defaultStateColorMap: Record<string, IStateColorConfig> = {
         draft: {type: 'default', style: 'hollow'},
         ingested: {type: 'primary', style: 'hollow'},
         routed: {type: 'primary', style: 'hollow'},
@@ -53,10 +36,10 @@ export class StateLabel extends React.PureComponent<IProps> {
         unpublished: {type: 'alert', style: 'hollow'},
     };
 
-    private getColorConfig(state: StateType): IStateColorConfig {
+    private getColorConfig(state: string): IStateColorConfig {
         const {mappingOverride} = this.props;
         const override = mappingOverride?.[state];
-        const defaultConfig = this.stateColorMap[state] || {type: 'default'};
+        const defaultConfig = this.defaultStateColorMap[state] || {type: 'default'};
 
         return override ? {...defaultConfig, ...override} : defaultConfig;
     }

--- a/app-typescript/components/StateLabel.tsx
+++ b/app-typescript/components/StateLabel.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import {Label} from './Label';
+
+type StateType =
+    | 'draft'
+    | 'ingested'
+    | 'routed'
+    | 'fetched'
+    | 'submitted'
+    | 'in_progress'
+    | 'published'
+    | 'spiked'
+    | 'scheduled'
+    | 'corrected'
+    | 'killed'
+    | 'recalled'
+    | 'unpublished'
+    | 'correction'
+    | 'being_corrected';
+
+interface IStateColorConfig {
+    type?: 'default' | 'primary' | 'success' | 'warning' | 'alert' | 'highlight' | 'sd-green';
+    color?: string;
+    style?: 'filled' | 'hollow';
+}
+
+interface IProps {
+    state: StateType;
+    text: string;
+    onClick?: () => void;
+    color?: string;
+    noTransform?: boolean;
+    size?: 'small' | 'normal' | 'large';
+}
+
+export class StateLabel extends React.PureComponent<IProps> {
+    private stateColorMap: Record<StateType, IStateColorConfig> = {
+        draft: {type: 'default', style: 'hollow'},
+        ingested: {type: 'primary', style: 'hollow'},
+        routed: {type: 'primary', style: 'hollow'},
+        fetched: {type: 'primary', style: 'hollow'},
+        submitted: {type: 'warning', style: 'hollow'},
+        in_progress: {type: 'warning', style: 'hollow'},
+        published: {type: 'success', style: 'hollow'},
+        spiked: {type: 'alert', style: 'hollow'},
+        recalled: {type: 'alert', style: 'hollow'},
+        killed: {type: 'alert', style: 'hollow'},
+        scheduled: {type: 'highlight', style: 'hollow'},
+        corrected: {type: 'sd-green', style: 'hollow'},
+        correction: {color: 'pink--500', style: 'filled'},
+        being_corrected: {color: 'pink--500', style: 'hollow'},
+        unpublished: {type: 'alert', style: 'hollow'},
+    };
+
+    private getColorConfig(state: StateType): IStateColorConfig {
+        return this.stateColorMap[state] || {type: 'default'};
+    }
+
+    render() {
+        const {state, text, onClick, color, noTransform, size} = this.props;
+        const colorConfig = this.getColorConfig(state);
+
+        return (
+            <Label
+                text={text}
+                type={color ? undefined : colorConfig.type}
+                color={color || colorConfig.color}
+                style={colorConfig.style || 'hollow'}
+                onClick={onClick}
+                noTransform={noTransform}
+                size={size}
+            />
+        );
+    }
+}

--- a/app-typescript/components/StateLabel.tsx
+++ b/app-typescript/components/StateLabel.tsx
@@ -31,6 +31,7 @@ interface IProps {
     color?: string;
     noTransform?: boolean;
     size?: 'small' | 'normal' | 'large';
+    mappingOverride?: Partial<Record<StateType, IStateColorConfig>>;
 }
 
 export class StateLabel extends React.PureComponent<IProps> {
@@ -53,7 +54,11 @@ export class StateLabel extends React.PureComponent<IProps> {
     };
 
     private getColorConfig(state: StateType): IStateColorConfig {
-        return this.stateColorMap[state] || {type: 'default'};
+        const {mappingOverride} = this.props;
+        const override = mappingOverride?.[state];
+        const defaultConfig = this.stateColorMap[state] || {type: 'default'};
+
+        return override ? {...defaultConfig, ...override} : defaultConfig;
     }
 
     render() {

--- a/app-typescript/components/StateLabel.tsx
+++ b/app-typescript/components/StateLabel.tsx
@@ -1,6 +1,24 @@
 import * as React from 'react';
 import {Label} from './Label';
 
+type StateType =
+    | 'draft'
+    | 'ingested'
+    | 'routed'
+    | 'fetched'
+    | 'submitted'
+    | 'in_progress'
+    | 'published'
+    | 'spiked'
+    | 'scheduled'
+    | 'corrected'
+    | 'killed'
+    | 'recalled'
+    | 'unpublished'
+    | 'correction'
+    | 'being_corrected'
+    | string;
+
 interface IStateColorConfig {
     type?: 'default' | 'primary' | 'success' | 'warning' | 'alert' | 'highlight' | 'sd-green';
     color?: string;
@@ -8,13 +26,13 @@ interface IStateColorConfig {
 }
 
 interface IProps {
-    state: string;
+    state: StateType;
     text: string;
     onClick?: () => void;
     color?: string;
     noTransform?: boolean;
     size?: 'small' | 'normal' | 'large';
-    mappingOverride?: Record<string, IStateColorConfig>;
+    mappingOverride?: Partial<Record<StateType, IStateColorConfig>>;
 }
 
 export class StateLabel extends React.PureComponent<IProps> {
@@ -36,7 +54,7 @@ export class StateLabel extends React.PureComponent<IProps> {
         unpublished: {type: 'alert', style: 'hollow'},
     };
 
-    private getColorConfig(state: string): IStateColorConfig {
+    private getColorConfig(state: StateType): IStateColorConfig {
         const {mappingOverride} = this.props;
         const override = mappingOverride?.[state];
         const defaultConfig = this.defaultStateColorMap[state] || {type: 'default'};

--- a/app-typescript/index.ts
+++ b/app-typescript/index.ts
@@ -11,6 +11,7 @@ export {SelectWithTemplate} from './components/SelectWithTemplate';
 export {WithPagination} from './components/WithPagination';
 export {Popover} from './components/Popover';
 export {Label} from './components/Label';
+export {StateLabel} from './components/StateLabel';
 export {Card} from './components/Card';
 export {Badge} from './components/Badge';
 export {Alert} from './components/Alert';

--- a/examples/pages/components/Index.tsx
+++ b/examples/pages/components/Index.tsx
@@ -11,6 +11,7 @@ import AutocompleteDoc from './Autocomplete';
 import SelectsDoc from './Selects';
 import ButtonsDoc from './Buttons';
 import LabelsDoc from './Labels';
+import StateLabelDoc from './StateLabel';
 import ButtonGroupsDoc from './ButtonGroups';
 import BadgesDoc from './Badges';
 import AlertDoc from './Alerts';
@@ -125,6 +126,10 @@ const pages: IPages = {
             labels: {
                 name: 'Labels',
                 component: LabelsDoc,
+            },
+            'state-label': {
+                name: 'State Labels',
+                component: StateLabelDoc,
             },
             'icon-labels': {
                 name: 'Icon Labels',

--- a/examples/pages/components/StateLabel.tsx
+++ b/examples/pages/components/StateLabel.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import * as Markup from '../../js/react';
+import {StateLabel, Prop, PropsList} from '../../../app-typescript';
+
+export default class StateLabelDoc extends React.Component {
+    render() {
+        return (
+            <section className="docs-page__container">
+                <h2 className="docs-page__h2">State Label</h2>
+                <Markup.ReactMarkupCodePreview>
+                    {`
+                    <StateLabel state="published" text="Published" />
+                `}
+                </Markup.ReactMarkupCodePreview>
+                <p className="docs-page__paragraph">
+                    Display item states with predefined semantic colors. Currently supports 15 states with automatic
+                    color mapping.
+                </p>
+
+                <h3 className="docs-page__h3">All States</h3>
+                <Markup.ReactMarkup>
+                    <Markup.ReactMarkupPreview>
+                        <div className="docs-page__content-row">
+                            <div style={{display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center'}}>
+                                <StateLabel state="draft" text="Draft" />
+                                <StateLabel state="ingested" text="Ingested" />
+                                <StateLabel state="routed" text="Routed" />
+                                <StateLabel state="fetched" text="Fetched" />
+                                <StateLabel state="submitted" text="Submitted" />
+                                <StateLabel state="in_progress" text="In Progress" />
+                                <StateLabel state="published" text="Published" />
+                                <StateLabel state="spiked" text="Spiked" />
+                                <StateLabel state="recalled" text="Recalled" />
+                                <StateLabel state="killed" text="Killed" />
+                                <StateLabel state="scheduled" text="Scheduled" />
+                                <StateLabel state="corrected" text="Corrected" />
+                                <StateLabel state="correction" text="Correction" />
+                                <StateLabel state="being_corrected" text="Being Corrected" />
+                                <StateLabel state="unpublished" text="Unpublished" />
+                            </div>
+                        </div>
+                    </Markup.ReactMarkupPreview>
+                    <Markup.ReactMarkupCode>
+                        {`
+                        <StateLabel state="draft" text="Draft" />
+                        <StateLabel state="ingested" text="Ingested" />
+                        <StateLabel state="routed" text="Routed" />
+                        <StateLabel state="fetched" text="Fetched" />
+                        <StateLabel state="submitted" text="Submitted" />
+                        <StateLabel state="in_progress" text="In Progress" />
+                        <StateLabel state="published" text="Published" />
+                        <StateLabel state="spiked" text="Spiked" />
+                        <StateLabel state="recalled" text="Recalled" />
+                        <StateLabel state="killed" text="Killed" />
+                        <StateLabel state="scheduled" text="Scheduled" />
+                        <StateLabel state="corrected" text="Corrected" />
+                        <StateLabel state="correction" text="Correction" />
+                        <StateLabel state="being_corrected" text="Being Corrected" />
+                        <StateLabel state="unpublished" text="Unpublished" />
+                    `}
+                    </Markup.ReactMarkupCode>
+                </Markup.ReactMarkup>
+
+                <h3 className="docs-page__h3">With Click Handler</h3>
+                <Markup.ReactMarkup>
+                    <Markup.ReactMarkupPreview>
+                        <div className="docs-page__content-row">
+                            <StateLabel
+                                state="being_corrected"
+                                text="Click me to open article"
+                                onClick={() => alert('Article opened!')}
+                            />
+                        </div>
+                    </Markup.ReactMarkupPreview>
+                    <Markup.ReactMarkupCode>
+                        {`
+                        <StateLabel
+                            state="being_corrected"
+                            text="Click me to open article"
+                            onClick={() => alert('Article opened!')}
+                        />
+                    `}
+                    </Markup.ReactMarkupCode>
+                </Markup.ReactMarkup>
+
+                <h3 className="docs-page__h3">Different Sizes</h3>
+                <Markup.ReactMarkup>
+                    <Markup.ReactMarkupPreview>
+                        <div className="docs-page__content-row">
+                            <div style={{display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center'}}>
+                                <StateLabel state="published" text="Small" size="small" />
+                                <StateLabel state="published" text="Normal" size="normal" />
+                                <StateLabel state="published" text="Large" size="large" />
+                            </div>
+                        </div>
+                    </Markup.ReactMarkupPreview>
+                    <Markup.ReactMarkupCode>
+                        {`
+                        <StateLabel state="published" text="Small" size="small" />
+                        <StateLabel state="published" text="Normal" size="normal" />
+                        <StateLabel state="published" text="Large" size="large" />
+                    `}
+                    </Markup.ReactMarkupCode>
+                </Markup.ReactMarkup>
+
+                <h3 className="docs-page__h3">Props</h3>
+                <PropsList>
+                    <Prop
+                        name="state"
+                        isRequired={true}
+                        type="StateType"
+                        default="/"
+                        description="The item state value (draft, published, etc.)"
+                    />
+                    <Prop name="text" isRequired={true} type="string" default="/" description="Label text to display" />
+                    <Prop name="onClick" isRequired={false} type="() => void" default="/" description="Click handler" />
+                    <Prop
+                        name="color"
+                        isRequired={false}
+                        type="string"
+                        default="/"
+                        description="Custom color override (e.g. red--500); NOTE: When defined, it overrides the state's predefined color"
+                    />
+                    <Prop
+                        name="size"
+                        isRequired={false}
+                        type="small | normal | large"
+                        default="normal"
+                        description="Label size"
+                    />
+                    <Prop
+                        name="noTransform"
+                        isRequired={false}
+                        type="boolean"
+                        default="false"
+                        description="Disable uppercase text transformation"
+                    />
+                </PropsList>
+            </section>
+        );
+    }
+}

--- a/examples/pages/components/StateLabel.tsx
+++ b/examples/pages/components/StateLabel.tsx
@@ -160,14 +160,70 @@ export default class StateLabelDoc extends React.Component {
                     </Markup.ReactMarkupCode>
                 </Markup.ReactMarkup>
 
+                <h3 className="docs-page__h3">Custom States</h3>
+                <p className="docs-page__paragraph">
+                    Support any custom state string with full mapping control. Define custom states with their own
+                    colors and styles.
+                </p>
+                <Markup.ReactMarkup>
+                    <Markup.ReactMarkupPreview>
+                        <div className="docs-page__content-row">
+                            <div style={{display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center'}}>
+                                <StateLabel
+                                    state="overthink"
+                                    text="Overthink"
+                                    mappingOverride={{
+                                        overthink: {type: 'highlight', style: 'filled'},
+                                    }}
+                                />
+                                <StateLabel
+                                    state="archived"
+                                    text="Archived"
+                                    mappingOverride={{
+                                        archived: {color: 'gray--500', style: 'hollow'},
+                                    }}
+                                />
+                                <StateLabel
+                                    state="custom_state"
+                                    text="Custom State"
+                                    mappingOverride={{
+                                        custom_state: {type: 'primary', style: 'filled'},
+                                    }}
+                                />
+                            </div>
+                        </div>
+                    </Markup.ReactMarkupPreview>
+                    <Markup.ReactMarkupCode>
+                        {`
+                        {/* Custom state with semantic type */}
+                        <StateLabel
+                            state="overthink"
+                            text="Overthink"
+                            mappingOverride={{
+                                overthink: {type: 'highlight', style: 'filled'}
+                            }}
+                        />
+
+                        {/* Custom state with custom color */}
+                        <StateLabel
+                            state="archived"
+                            text="Archived"
+                            mappingOverride={{
+                                archived: {color: 'gray--500', style: 'hollow'}
+                            }}
+                        />
+                    `}
+                    </Markup.ReactMarkupCode>
+                </Markup.ReactMarkup>
+
                 <h3 className="docs-page__h3">Props</h3>
                 <PropsList>
                     <Prop
                         name="state"
                         isRequired={true}
-                        type="StateType"
+                        type="string"
                         default="/"
-                        description="The item state value (draft, published, etc.)"
+                        description="The item state value. Supports predefined states (draft, published, etc.) or any custom state string"
                     />
                     <Prop name="text" isRequired={true} type="string" default="/" description="Label text to display" />
                     <Prop name="onClick" isRequired={false} type="() => void" default="/" description="Click handler" />
@@ -195,9 +251,9 @@ export default class StateLabelDoc extends React.Component {
                     <Prop
                         name="mappingOverride"
                         isRequired={false}
-                        type="Partial<Record<StateType, IStateColorConfig>>"
+                        type="Record<string, IStateColorConfig>"
                         default="undefined"
-                        description="Override state-to-color mapping with custom type, color, and style"
+                        description="Override or define state-to-color mapping. Works with both predefined and custom states"
                     />
                 </PropsList>
             </section>

--- a/examples/pages/components/StateLabel.tsx
+++ b/examples/pages/components/StateLabel.tsx
@@ -103,6 +103,63 @@ export default class StateLabelDoc extends React.Component {
                     </Markup.ReactMarkupCode>
                 </Markup.ReactMarkup>
 
+                <h3 className="docs-page__h3">Custom State Mapping</h3>
+                <p className="docs-page__paragraph">Override default state-to-color mapping for specific states.</p>
+                <Markup.ReactMarkup>
+                    <Markup.ReactMarkupPreview>
+                        <div className="docs-page__content-row">
+                            <div style={{display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center'}}>
+                                <StateLabel state="draft" text="Draft (Default)" />
+                                <StateLabel
+                                    state="draft"
+                                    text="Draft (Custom Alert)"
+                                    mappingOverride={{
+                                        draft: {type: 'alert', style: 'hollow'},
+                                    }}
+                                />
+                                <StateLabel
+                                    state="published"
+                                    text="Published (Custom Highlight)"
+                                    mappingOverride={{
+                                        published: {type: 'highlight', style: 'filled'},
+                                    }}
+                                />
+                            </div>
+                        </div>
+                    </Markup.ReactMarkupPreview>
+                    <Markup.ReactMarkupCode>
+                        {`
+                        {/* Override single state mapping */}
+                        <StateLabel
+                            state="draft"
+                            text="Draft (Custom Alert)"
+                            mappingOverride={{
+                                draft: {type: 'alert', style: 'hollow'}
+                            }}
+                        />
+
+                        {/* Override multiple state mappings */}
+                        <StateLabel
+                            state="published"
+                            text="Published (Custom)"
+                            mappingOverride={{
+                                draft: {type: 'alert'},
+                                published: {type: 'highlight', style: 'filled'}
+                            }}
+                        />
+
+                        {/* Override with custom color */}
+                        <StateLabel
+                            state="in_progress"
+                            text="In Progress (Custom Color)"
+                            mappingOverride={{
+                                in_progress: {color: 'blue--500', style: 'filled'}
+                            }}
+                        />
+                    `}
+                    </Markup.ReactMarkupCode>
+                </Markup.ReactMarkup>
+
                 <h3 className="docs-page__h3">Props</h3>
                 <PropsList>
                     <Prop
@@ -134,6 +191,13 @@ export default class StateLabelDoc extends React.Component {
                         type="boolean"
                         default="false"
                         description="Disable uppercase text transformation"
+                    />
+                    <Prop
+                        name="mappingOverride"
+                        isRequired={false}
+                        type="Partial<Record<StateType, IStateColorConfig>>"
+                        default="undefined"
+                        description="Override state-to-color mapping with custom type, color, and style"
                     />
                 </PropsList>
             </section>

--- a/examples/pages/components/StateLabel.tsx
+++ b/examples/pages/components/StateLabel.tsx
@@ -104,7 +104,9 @@ export default class StateLabelDoc extends React.Component {
                 </Markup.ReactMarkup>
 
                 <h3 className="docs-page__h3">Custom State Mapping</h3>
-                <p className="docs-page__paragraph">Override default state-to-color mapping for specific states.</p>
+                <p className="docs-page__paragraph">
+                    Override default state-to-color mapping or define custom states with their own colors and styles.
+                </p>
                 <Markup.ReactMarkup>
                     <Markup.ReactMarkupPreview>
                         <div className="docs-page__content-row">
@@ -118,10 +120,10 @@ export default class StateLabelDoc extends React.Component {
                                     }}
                                 />
                                 <StateLabel
-                                    state="published"
-                                    text="Published (Custom Highlight)"
+                                    state="archived"
+                                    text="Archived"
                                     mappingOverride={{
-                                        published: {type: 'highlight', style: 'filled'},
+                                        archived: {color: 'gray--500', style: 'hollow'},
                                     }}
                                 />
                             </div>
@@ -129,7 +131,10 @@ export default class StateLabelDoc extends React.Component {
                     </Markup.ReactMarkupPreview>
                     <Markup.ReactMarkupCode>
                         {`
-                        {/* Override single state mapping */}
+                        {/* Predefined state with default mapping */}
+                        <StateLabel state="draft" text="Draft (Default)" />
+
+                        {/* Override predefined state mapping */}
                         <StateLabel
                             state="draft"
                             text="Draft (Custom Alert)"
@@ -138,73 +143,7 @@ export default class StateLabelDoc extends React.Component {
                             }}
                         />
 
-                        {/* Override multiple state mappings */}
-                        <StateLabel
-                            state="published"
-                            text="Published (Custom)"
-                            mappingOverride={{
-                                draft: {type: 'alert'},
-                                published: {type: 'highlight', style: 'filled'}
-                            }}
-                        />
-
-                        {/* Override with custom color */}
-                        <StateLabel
-                            state="in_progress"
-                            text="In Progress (Custom Color)"
-                            mappingOverride={{
-                                in_progress: {color: 'blue--500', style: 'filled'}
-                            }}
-                        />
-                    `}
-                    </Markup.ReactMarkupCode>
-                </Markup.ReactMarkup>
-
-                <h3 className="docs-page__h3">Custom States</h3>
-                <p className="docs-page__paragraph">
-                    Support any custom state string with full mapping control. Define custom states with their own
-                    colors and styles.
-                </p>
-                <Markup.ReactMarkup>
-                    <Markup.ReactMarkupPreview>
-                        <div className="docs-page__content-row">
-                            <div style={{display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center'}}>
-                                <StateLabel
-                                    state="overthink"
-                                    text="Overthink"
-                                    mappingOverride={{
-                                        overthink: {type: 'highlight', style: 'filled'},
-                                    }}
-                                />
-                                <StateLabel
-                                    state="archived"
-                                    text="Archived"
-                                    mappingOverride={{
-                                        archived: {color: 'gray--500', style: 'hollow'},
-                                    }}
-                                />
-                                <StateLabel
-                                    state="custom_state"
-                                    text="Custom State"
-                                    mappingOverride={{
-                                        custom_state: {type: 'primary', style: 'filled'},
-                                    }}
-                                />
-                            </div>
-                        </div>
-                    </Markup.ReactMarkupPreview>
-                    <Markup.ReactMarkupCode>
-                        {`
-                        {/* Custom state with semantic type */}
-                        <StateLabel
-                            state="overthink"
-                            text="Overthink"
-                            mappingOverride={{
-                                overthink: {type: 'highlight', style: 'filled'}
-                            }}
-                        />
-
-                        {/* Custom state with custom color */}
+                        {/* Custom state with mapping */}
                         <StateLabel
                             state="archived"
                             text="Archived"
@@ -221,9 +160,9 @@ export default class StateLabelDoc extends React.Component {
                     <Prop
                         name="state"
                         isRequired={true}
-                        type="string"
+                        type="StateType"
                         default="/"
-                        description="The item state value. Supports predefined states (draft, published, etc.) or any custom state string"
+                        description="The item state value. One of 15 predefined states (draft, published, etc.) or any custom state string"
                     />
                     <Prop name="text" isRequired={true} type="string" default="/" description="Label text to display" />
                     <Prop name="onClick" isRequired={false} type="() => void" default="/" description="Click handler" />
@@ -251,9 +190,9 @@ export default class StateLabelDoc extends React.Component {
                     <Prop
                         name="mappingOverride"
                         isRequired={false}
-                        type="Record<string, IStateColorConfig>"
+                        type="Partial<Record<StateType, IStateColorConfig>>"
                         default="undefined"
-                        description="Override or define state-to-color mapping. Works with both predefined and custom states"
+                        description="Override or define state-to-color mapping. Works with predefined and custom states"
                     />
                 </PropsList>
             </section>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Purpose
- Create new StateLabel component that wraps Label component with predefined color mappings for 15 item states
- Supports both filled and hollow style variants
- Added example page

### Screenshot
<img width="950" height="242" alt="2026-01-15_17-37-03" src="https://github.com/user-attachments/assets/0dab307d-d040-4e23-963f-41e7652fdf36" />

[STT-1509](https://sofab.atlassian.net/browse/STT-1509)


[STT-1509]: https://sofab.atlassian.net/browse/STT-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ