### PR TITLE
Add icon type property to the sidebar

### DIFF
--- a/app-typescript/components/Icon.tsx
+++ b/app-typescript/components/Icon.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
-export interface IconProps {
+export interface IIconProps {
     name?: string;
     size?: 'small' | 'big'; // defaults to 'small'
     type?: 'default' | 'primary' | 'success' | 'warning' | 'alert' | 'highlight' | 'light' | 'white';
@@ -11,7 +11,7 @@ export interface IconProps {
     color?: string;
 }
 
-export class Icon extends React.PureComponent<IconProps> {
+export class Icon extends React.PureComponent<IIconProps> {
     render() {
         let classes = classNames(this.props.className, {
             [`icon-${this.props.name}`]:

--- a/app-typescript/components/Icon.tsx
+++ b/app-typescript/components/Icon.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
-interface IProps {
+
+export interface IconProps {
     name?: string;
     size?: 'small' | 'big'; // defaults to 'small'
     type?: 'default' | 'primary' | 'success' | 'warning' | 'alert' | 'highlight' | 'light' | 'white';
@@ -10,7 +11,7 @@ interface IProps {
     color?: string;
 }
 
-export class Icon extends React.PureComponent<IProps> {
+export class Icon extends React.PureComponent<IconProps> {
     render() {
         let classes = classNames(this.props.className, {
             [`icon-${this.props.name}`]:

--- a/app-typescript/components/Navigation/SideBarTabs.tsx
+++ b/app-typescript/components/Navigation/SideBarTabs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Icon, IconProps} from '../Icon';
+import {Icon, IIconProps} from '../Icon';
 import {Badge} from '../Badge';
 import classNames from 'classnames';
 
@@ -15,7 +15,7 @@ interface IProps {
 export interface ISideBarTab {
     id: string;
     icon: string;
-    type: IconProps['type'];
+    type?: IIconProps['type'];
     size: 'small' | 'big'; // defaults to 'small'
     tooltip?: string;
     badgeValue?: string;

--- a/app-typescript/components/Navigation/SideBarTabs.tsx
+++ b/app-typescript/components/Navigation/SideBarTabs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Icon} from '../Icon';
+import {Icon, IconProps} from '../Icon';
 import {Badge} from '../Badge';
 import classNames from 'classnames';
 
@@ -15,6 +15,7 @@ interface IProps {
 export interface ISideBarTab {
     id: string;
     icon: string;
+    type: IconProps['type'];
     size: 'small' | 'big'; // defaults to 'small'
     tooltip?: string;
     badgeValue?: string;
@@ -68,7 +69,7 @@ export class SideBarTabs extends React.PureComponent<IProps> {
                                         {item.badgeValue != null && <Badge text={item['badgeValue']} type="primary" />}
 
                                         <span className="sd-sidetab-menu__main-icon ">
-                                            <Icon size={item['size']} name={item['icon']} />
+                                            <Icon size={item.size} name={item.icon} type={item.type} />
                                         </span>
 
                                         <i className="sd-sidetab-menu__helper-icon icon-close-small"></i>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "superdesk-ui-framework",
-            "version": "6.1.1",
+            "version": "6.1.2",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@popperjs/core": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Purpose

Allow developers to specify different icon types in the Sidebar

[SDESK-7447]


[SDESK-7447]: https://sofab.atlassian.net/browse/SDESK-7447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ