### PR TITLE
Make npm publish workflow manual-only and use npm trusted channels

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,63 +1,68 @@
 name: Publish to npm and Create Release
 
 on:
-    push:
-        branches:
-            - 'v3'
-            - 'v4'
-            - 'v5'
-            - 'v6*'
     workflow_dispatch:
         inputs:
-            branch:
-                description: 'Branch to publish from (leave empty to use current branch)'
-                required: false
-                type: string
-                default: ''
+            bump:
+                description: 'Version bump before publishing (none = publish current package.json version)'
+                required: true
+                type: choice
+                default: 'none'
+                options:
+                    - none
+                    - patch
+                    - minor
+                    - major
 
 jobs:
     publish:
         runs-on: ubuntu-latest
         permissions:
             contents: write
+            id-token: write
         steps:
             - uses: actions/checkout@v6
               with:
-                  ref: ${{ github.event.inputs.branch || github.ref }}
                   fetch-depth: 0
             - uses: actions/setup-node@v6
               with:
                   node-version: '22'
+            - run: npm install -g npm@latest
             - run: npm ci
-            - run: npm run lint
-            - run: npm run build
-            - uses: JS-DevTools/npm-publish@v4
-              id: publish
-              continue-on-error: true
-              with:
-                  token: ${{ secrets.NPM_TOKEN }}
 
-            - name: Check publish result
-              if: steps.publish.outcome == 'failure'
-              run: |
-                  echo "::notice::Package was not published. Version may already exist on npm."
-                  exit 0
-
-            - name: Get package version
-              if: steps.publish.outputs.type != 'none' && steps.publish.outcome == 'success'
-              id: package-version
-              run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
-            - name: Create Git tag
-              if: steps.publish.outputs.type != 'none' && steps.publish.outcome == 'success'
+            - name: Bump version
+              if: inputs.bump != 'none'
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git tag -a "v${{ steps.package-version.outputs.version }}" -m "Release v${{ steps.package-version.outputs.version }}"
+                  npm version ${{ inputs.bump }} -m "Bump version to %s and release"
+
+            - name: Resolve target version
+              id: package-version
+              run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+            - name: Ensure version is not already published
+              run: |
+                  VERSION="${{ steps.package-version.outputs.version }}"
+                  if [ -n "$(npm view superdesk-ui-framework@"$VERSION" version 2>/dev/null)" ]; then
+                      echo "::error::superdesk-ui-framework@$VERSION is already published to npm. Choose a version bump (patch/minor/major) and re-run."
+                      exit 1
+                  fi
+                  echo "::notice::superdesk-ui-framework@$VERSION is available; proceeding to publish."
+
+            - run: npm run lint
+            - run: npm run build
+
+            - uses: JS-DevTools/npm-publish@v4
+              id: publish
+
+            - name: Push version bump and tag
+              if: inputs.bump != 'none'
+              run: |
+                  git push origin HEAD
                   git push origin "v${{ steps.package-version.outputs.version }}"
 
             - name: Create GitHub Release
-              if: steps.publish.outputs.type != 'none' && steps.publish.outcome == 'success'
               uses: softprops/action-gh-release@v1
               with:
                   tag_name: v${{ steps.package-version.outputs.version }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -27,7 +27,7 @@ jobs:
             - uses: actions/setup-node@v6
               with:
                   node-version: '22'
-            - run: npm install -g npm@latest
+            - run: npm install -g npm@11
             - run: npm ci
 
             - name: Bump version
@@ -55,15 +55,17 @@ jobs:
 
             - uses: JS-DevTools/npm-publish@v4
               id: publish
+              with:
+                  provenance: true
 
             - name: Push version bump and tag
               if: inputs.bump != 'none'
               run: |
-                  git push origin HEAD
+                  git push origin "HEAD:${{ github.ref_name }}"
                   git push origin "v${{ steps.package-version.outputs.version }}"
 
             - name: Create GitHub Release
-              uses: softprops/action-gh-release@v1
+              uses: softprops/action-gh-release@v3
               with:
                   tag_name: v${{ steps.package-version.outputs.version }}
                   name: v${{ steps.package-version.outputs.version }}


### PR DESCRIPTION
## Purpose

Reworks `.github/workflows/publish-to-npm.yml` to publish **manually only** and to use **npm trusted publishing (OIDC)** instead of a long-lived `NPM_TOKEN` https://docs.npmjs.com/trusted-publishers.

## What has changed

- **Manual-only trigger.** Removes the `push` trigger; publishing now runs via `workflow_dispatch`. The built-in "Use workflow from" branch picker selects which ref to publish, so the custom `branch` input is gone (checkout follows `github.ref`).
- **Version bump input.** Adds a `bump` choice input (`none`/`patch`/`minor`/`major`, default `none`). When set, `npm version` bumps `package.json` and `package-lock.json` and creates the commit and tag using the verified `github-actions[bot]` identity. The commit and tag are pushed only after a successful publish, so a failed publish leaves no orphan bump on the branch.
- **OIDC trusted publishing.** Adds `id-token: write`, pins npm to `npm@11` (Node 22 ships npm 10.x, and OIDC needs 11.5.1+), removes `NPM_TOKEN`, and enables build provenance on publish.
- **Pre-publish guard.** Fails the run with an actionable message if the target version already exists on npm, instead of silently doing nothing.
- **No more failure masking.** Removes `continue-on-error` and the notice step so real publish failures surface.


#### Trusted channels enabled for the repo's workflow
<img width="900" alt="image" src="https://github.com/user-attachments/assets/daa10eb7-b441-4256-a169-41ce5441a195" />


## Rollout

1. Merge here on `develop` first so the `workflow_dispatch` "Run workflow" button appears in the Actions UI.
2. Then I will cherry-pick into `v6.0` and `v5.1`.

Resolves: [SDESK-7846]

[SDESK-7846]: https://sofab.atlassian.net/browse/SDESK-7846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ