### PR TITLE
Remove dead orphan pr-superdesk-theme.scss

### DIFF
--- a/app/styles/pr-superdesk-theme.scss
+++ b/app/styles/pr-superdesk-theme.scss
@@ -1,7 +1,0 @@
-@import 'primereact/pr-general.scss';
-@import 'primereact/pr-autocomplete.scss';
-@import 'primereact/pr-dropdown.scss';
-@import 'primereact/pr-datepicker.scss';
-@import 'primereact/pr-dialog.scss';
-@import 'primereact/pr-menu.scss';
-@import 'primereact/pr-skeleton.scss';


### PR DESCRIPTION
### Purpose
Remove a dead SCSS file leftover from the `@use` refactor.

### What has changed
Deletes `app/styles/pr-superdesk-theme.scss`. Nothing references it: `app.scss` already loads the seven primereact partials it listed (`pr-general`, `pr-autocomplete`, `pr-dropdown`, `pr-datepicker` via the `_pr-superdesk-theme.scss` partial, and `pr-dialog`, `pr-menu`, `pr-skeleton` via direct `meta.load-css` calls). The file was not in any compilation graph, so the bundle is unchanged.

### Steps to test
- Build storybook / bundle; primereact-themed components render as before.
- `grep -rn "pr-superdesk-theme" .` should return only `app.scss:119` (the `_pr-superdesk-theme` underscore partial, a different file).

### Checklist
- [x] I reviewed my code
- [ ] I tested all affected functionality and made sure it works