### PR TITLE
[SDESK-7802] - Expand Menu component for grouped action menus

### DIFF
--- a/app-typescript/components/Menu.tsx
+++ b/app-typescript/components/Menu.tsx
@@ -30,7 +30,7 @@ import {getNextZIndex} from '../zIndex';
  * * ENTER/ESC or arrow keys work for entering/leaving submenus
  */
 
-export type IMenuItem = IMenuBranch | IMenuLeaf | ISeparator;
+export type IMenuItem = IMenuBranch | IMenuLeaf | IMenuGroup | IMenuSwitch | ISeparator;
 
 /**
  * Available icons are listed here:
@@ -47,12 +47,28 @@ interface IMenuLeaf {
     icon?: IIconName;
     onClick(): void;
     disabled?: boolean;
+    shortcut?: string;
+    closeOnSelect?: boolean; // defaults to true
 }
 
 interface IMenuBranch {
     label: string | JSX.Element;
     icon?: IIconName;
     children: Array<IMenuItem>;
+}
+
+interface IMenuGroup {
+    type: 'group';
+    label: string | JSX.Element;
+    children: Array<IMenuItem>;
+}
+
+interface IMenuSwitch {
+    type: 'switch';
+    label: string | JSX.Element;
+    value: boolean;
+    disabled?: boolean;
+    onChange(value: boolean): void;
 }
 
 interface IProps {
@@ -69,8 +85,34 @@ function isMenuLeaf(item: IMenuItem): item is IMenuLeaf {
     return (item as any)['onClick'] != null;
 }
 
+function isMenuGroup(item: IMenuItem): item is IMenuGroup {
+    return (item as any)['type'] === 'group';
+}
+
+function isMenuSwitch(item: IMenuItem): item is IMenuSwitch {
+    return (item as any)['type'] === 'switch';
+}
+
 function isMenuBranch(item: IMenuItem): item is IMenuBranch {
-    return isSeparator(item) !== true && isMenuLeaf(item) !== true;
+    return (
+        isSeparator(item) !== true &&
+        isMenuLeaf(item) !== true &&
+        isMenuGroup(item) !== true &&
+        isMenuSwitch(item) !== true
+    );
+}
+
+function getMenuRowLabel(label: string | JSX.Element, endAdornment?: string | JSX.Element): string | JSX.Element {
+    if (endAdornment == null) {
+        return label;
+    }
+
+    return (
+        <span className="sd-menuitem__content">
+            <span className="sd-menuitem__label">{label}</span>
+            <span className="sd-menuitem__end-adornment">{endAdornment}</span>
+        </span>
+    );
 }
 
 export class Menu extends React.Component<IProps, {}> {
@@ -90,31 +132,73 @@ export class Menu extends React.Component<IProps, {}> {
     }
 
     private toPrimeReactInterface(items: Array<IMenuItem>): Array<IPrimeMenuItem> {
-        return items.map((item) => {
+        return items.flatMap((item) => {
             if (isSeparator(item)) {
-                return {separator: true};
-            } else if (isMenuBranch(item)) {
-                return {
-                    label: item.label as string,
-                    icon: item.icon,
-                    items: this.toPrimeReactInterface(item.children),
-                };
-            } else if (isMenuLeaf(item)) {
-                return {
-                    label: item.label as string,
-                    icon: item.icon,
-                    command: (event) => {
-                        /**
-                         * a click on menu item should not trigger other click handlers
-                         * above in the DOM tree. e.g. if menu is inside a clickable list item
-                         */
-                        event.originalEvent.stopPropagation();
-
-                        this.close(event.originalEvent as unknown as SyntheticEvent);
-                        item.onClick();
+                return [{separator: true}];
+            } else if (isMenuGroup(item)) {
+                return [
+                    {
+                        label: item.label as string,
+                        disabled: true,
+                        className: 'p-menuitem--group-label',
                     },
-                    disabled: item.disabled,
-                };
+                    ...this.toPrimeReactInterface(item.children),
+                ];
+            } else if (isMenuSwitch(item)) {
+                return [
+                    {
+                        label: getMenuRowLabel(
+                            item.label,
+                            <span className={`sd-switch ${item.value ? 'checked' : ''}`}>
+                                <span className="inner" />
+                            </span>,
+                        ) as string,
+                        className: 'p-menuitem--switch',
+                        command: (event) => {
+                            event.originalEvent.stopPropagation();
+
+                            if (item.disabled !== true) {
+                                item.onChange(!item.value);
+                            }
+                        },
+                        disabled: item.disabled,
+                    },
+                ];
+            } else if (isMenuBranch(item)) {
+                return [
+                    {
+                        label: item.label as string,
+                        icon: item.icon,
+                        items: this.toPrimeReactInterface(item.children),
+                    },
+                ];
+            } else if (isMenuLeaf(item)) {
+                return [
+                    {
+                        label: getMenuRowLabel(
+                            item.label,
+                            item.shortcut == null ? undefined : (
+                                <span className="sd-menuitem__shortcut">{item.shortcut}</span>
+                            ),
+                        ) as string,
+                        icon: item.icon,
+                        className: item.closeOnSelect === false ? 'p-menuitem--keep-open' : undefined,
+                        command: (event) => {
+                            /**
+                             * a click on menu item should not trigger other click handlers
+                             * above in the DOM tree. e.g. if menu is inside a clickable list item
+                             */
+                            event.originalEvent.stopPropagation();
+
+                            if (item.closeOnSelect !== false) {
+                                this.close(event.originalEvent as unknown as SyntheticEvent);
+                            }
+
+                            item.onClick();
+                        },
+                        disabled: item.disabled,
+                    },
+                ];
             } else {
                 return assertNever(item);
             }

--- a/app-typescript/components/Menu.tsx
+++ b/app-typescript/components/Menu.tsx
@@ -78,19 +78,19 @@ interface IProps {
 }
 
 function isSeparator(item: IMenuItem): item is ISeparator {
-    return (item as any)['separator'] === true;
+    return 'separator' in item && item.separator === true;
 }
 
 function isMenuLeaf(item: IMenuItem): item is IMenuLeaf {
-    return (item as any)['onClick'] != null;
+    return 'onClick' in item;
 }
 
 function isMenuGroup(item: IMenuItem): item is IMenuGroup {
-    return (item as any)['type'] === 'group';
+    return 'type' in item && item.type === 'group';
 }
 
 function isMenuSwitch(item: IMenuItem): item is IMenuSwitch {
-    return (item as any)['type'] === 'switch';
+    return 'type' in item && item.type === 'switch';
 }
 
 function isMenuBranch(item: IMenuItem): item is IMenuBranch {

--- a/app/styles/primereact/_pr-menu.scss
+++ b/app/styles/primereact/_pr-menu.scss
@@ -14,10 +14,61 @@
         width: 100%;
         max-width: 36ch;
     }
+    .p-menuitem--group-label {
+        .p-menuitem-link {
+            padding-block: .4rem;
+            cursor: default;
+            opacity: 1;
+
+            &:hover, &:focus-visible {
+                background: transparent;
+            }
+        }
+
+        .p-menuitem-text {
+            text-transform: uppercase;
+            font-size: 1.1rem;
+            color: var(--color-text-subdued);
+            font-weight: 500;
+        }
+    }
+
+    .p-menuitem--switch {
+        .p-menuitem-link {
+            cursor: pointer;
+        }
+    }
+
+    .sd-menuitem__content {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 2rem;
+        width: 100%;
+    }
+
+    .sd-menuitem__label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .sd-menuitem__end-adornment {
+        flex-shrink: 0;
+        margin-inline-start: auto;
+    }
+
+    .sd-menuitem__shortcut {
+        color: var(--color-text-subdued);
+        font-size: 1.2rem;
+        font-style: italic;
+    }
+
     .p-menuitem-text {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        width: 100%;
     }
     .p-submenu-list {
         .p-menuitem-text {


### PR DESCRIPTION
### Purpose
This PR expands the Menu component so it can support richer action-menu layouts needed by consumers such as the superdesk authoring action bar menu.

### What has changed
1. Added new Menu item capabilities:
- Grouped sections via type: 'group'
- Switch/toggle rows via type: 'switch'
- Right-aligned shortcut text via shortcut
2. Updated menu styling to support:
- Uppercase group labels
- Right-aligned end adornments
- Shortcut text

### Steps to test
1. Link this branch into client-core and enable `auth-react` in localStorage for now.
2. Open a menu using the new item types.
3. Verify group labels render as section headers.
4. Verify shortcut text is aligned on the right side of a menu item.
5. Verify switch rows display correctly and toggles on click
6. Verify regular menu items behavior still work as before i.e they open the respective modals.

### Screenshots
| Before    | After |
| -------- | ------- |
| <img width="208" height="477" alt="image" src="https://github.com/user-attachments/assets/6dd59039-5bc7-42af-8fe3-a1bd81107b0d" /> |  <img width="208" height="603" alt="image" src="https://github.com/user-attachments/assets/ef298430-1088-41aa-bcee-068ebb19bf05" /> |


[SDESK-7802](https://sofab.atlassian.net/browse/SDESK-7802)


[SDESK-7802]: https://sofab.atlassian.net/browse/SDESK-7802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ