### PR TITLE
Fix `Dropdown` toggle typing for TypeScript 4.9 consumers

### DIFF
--- a/app-typescript/components/Dropdown.tsx
+++ b/app-typescript/components/Dropdown.tsx
@@ -215,7 +215,7 @@ export const Dropdown = ({items, header, footer, children, align, onChange, maxH
 
     return (
         <div className={open ? 'dropdown open' : 'dropdown'}>
-            {React.isValidElement(children) ? (
+            {React.isValidElement<React.HTMLAttributes<HTMLElement>>(children) ? (
                 // The wrapper (not the cloned child) is the popper anchor, so a plain
                 // function component can be used as the toggle without forwarding a ref.
                 <div ref={setButtonRef}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "7.0.0-dev2",
+    "version": "7.0.0-dev3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "superdesk-ui-framework",
-            "version": "7.0.0-dev2",
+            "version": "7.0.0-dev3",
             "license": "AGPL-3.0",
             "dependencies": {
                 "@hello-pangea/dnd": "^16.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superdesk-ui-framework",
-    "version": "7.0.0-dev2",
+    "version": "7.0.0-dev3",
     "license": "AGPL-3.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
### Purpose

`superdesk-client-core` cannot build against `7.0.0-dev2`. Its type-check fails inside our own source:

```
node_modules/superdesk-ui-framework/app-typescript/components/Dropdown.tsx:224:25 - error TS2769
  'className' does not exist in type 'Partial<unknown> & Attributes'
```

We build with TypeScript 5.9, client-core pins 4.9.5, and it imports `IMenuItem` straight from `app-typescript/components/Dropdown`, so it compiles our TSX with its own older compiler. Our CI only ever runs the compiler we use, so nothing caught this.

### What has changed

One line in `Dropdown.tsx`. Bare `React.isValidElement` infers `P` as `unknown`, which collapses the `cloneElement` props parameter to `Partial<unknown> & Attributes` and rejects `className`. Passing `P` explicitly types `children.props.className` as `string | undefined` and makes all four cloned props known members. No cast, no `any`, and it states the real contract: the toggle child has to accept standard HTML attributes.

Version bumped to `7.0.0-dev3` so this can be published.
